### PR TITLE
Enable Multi-Lap Live Data

### DIFF
--- a/F1Telemetry.Test/ModelTests/CurrentLapDataModelTest.cs
+++ b/F1Telemetry.Test/ModelTests/CurrentLapDataModelTest.cs
@@ -1,0 +1,40 @@
+﻿using F1Telemetry.WPF.Model;
+using FluentAssertions;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace F1Telemetry.Test.ModelTests
+{
+    public class CurrentLapDataModelTest
+    {
+        [Fact]
+        public void Clear_Should_Clear_The_Instance()
+        {
+            var model = new CurrentLapDataModel();
+            var expected = new CurrentLapDataModel();
+
+            var type = model.GetType();
+
+            var arrayFields = type.GetTypeInfo().DeclaredFields.Where(fi => fi.IsPublic && fi.FieldType.IsArray);
+
+            foreach (var arrayField in arrayFields)
+            {
+                var arr = arrayField.GetValue(model) as IList;
+                for (int i = 0; i < arr.Count; i++)
+                {
+                    arr[i] = 1.0;
+                }
+            }
+
+            model.Clear();
+
+            foreach (var arrayField in arrayFields)
+            {
+                var arr = arrayField.GetValue(model);
+                arr.Should().BeEquivalentTo(arrayField.GetValue(expected), because: "clear should reset the instance.");
+            }
+        }
+    }
+}

--- a/F1Telemetry.Test/ViewModelTest/MainViewModelTest.cs
+++ b/F1Telemetry.Test/ViewModelTest/MainViewModelTest.cs
@@ -1,0 +1,21 @@
+﻿using F1Telemetry.WPF.ViewModels;
+using FluentAssertions;
+using Xunit;
+
+namespace F1Telemetry.Test.ViewModelTest
+{
+    public class MainViewModelTest
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TopmostCommand_Should_Set_To_Given_Input(bool input)
+        {
+            var viewModel = new MainViewModel();
+
+            viewModel.SetTopmostCommand.Execute(input);
+
+            viewModel.IsTopmost.Should().Be(input, because: $"it is instructed to be set to {input}");
+        }
+    }
+}

--- a/F1Telemetry.WPF/MainWindow.xaml
+++ b/F1Telemetry.WPF/MainWindow.xaml
@@ -55,6 +55,7 @@
                 </Grid.ColumnDefinitions>
 
                 <StackPanel Grid.Column="0">
+                    <Label Content="Lap:" />
                     <Label Content="Time:" />
                     <Label Content="Spd:" />
                     <Label Content="RPM:" />
@@ -63,6 +64,7 @@
                 </StackPanel>
 
                 <StackPanel Grid.Column="1">
+                    <Label Content="{Binding LapNumber, UpdateSourceTrigger=PropertyChanged}" />
                     <Label Content="{Binding LapTime, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ToLapTimeString}}" />
                     <Label Content="{Binding Speed, UpdateSourceTrigger=PropertyChanged}" />
                     <Label Content="{Binding EngineRPM, UpdateSourceTrigger=PropertyChanged}" />

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -96,7 +96,7 @@ namespace F1Telemetry.WPF
 
             try
             {
-                int cursor = 0;
+                int indexCursor = 0;
 
                 telemetryManager.NewSession += (s, e) =>
                 {
@@ -141,7 +141,7 @@ namespace F1Telemetry.WPF
                         {
                             if (currentLapData.DriverStatus == DriverStatus.InGarage)
                             {
-                                cursor = 0;
+                                indexCursor = 0;
                             }
                             else
                             {
@@ -151,23 +151,23 @@ namespace F1Telemetry.WPF
 
                                 var lapNumberLabel = $"Lap {currentLapData.CurrentLapNum}";
 
-                                currentLapDataModel.Speed[cursor] = currentTelemetry.Speed;
-                                currentLapDataModel.Distance[cursor] = currentLapData.LapDistance;
-                                currentLapDataModel.Gear[cursor] = currentTelemetry.Gear;
+                                currentLapDataModel.Speed[indexCursor] = currentTelemetry.Speed;
+                                currentLapDataModel.Distance[indexCursor] = currentLapData.LapDistance;
+                                currentLapDataModel.Gear[indexCursor] = currentTelemetry.Gear;
 
-                                currentLapDataModel.Throttle[cursor] = currentTelemetry.Throttle;
-                                currentLapDataModel.Brake[cursor] = currentTelemetry.Brake;
+                                currentLapDataModel.Throttle[indexCursor] = currentTelemetry.Throttle;
+                                currentLapDataModel.Brake[indexCursor] = currentTelemetry.Brake;
 
-                                SpeedGraph[CurrentLapCursor].maxRenderIndex = cursor;
+                                SpeedGraph[CurrentLapCursor].maxRenderIndex = indexCursor;
                                 SpeedGraph[CurrentLapCursor].label = lapNumberLabel;
 
-                                GearGraph[CurrentLapCursor].maxRenderIndex = cursor;
+                                GearGraph[CurrentLapCursor].maxRenderIndex = indexCursor;
                                 GearGraph[CurrentLapCursor].label = lapNumberLabel;
 
-                                BrakeGraph[CurrentLapCursor].maxRenderIndex = cursor;
+                                BrakeGraph[CurrentLapCursor].maxRenderIndex = indexCursor;
                                 BrakeGraph[CurrentLapCursor].label = lapNumberLabel;
 
-                                ThrottleGraph[CurrentLapCursor].maxRenderIndex = cursor;
+                                ThrottleGraph[CurrentLapCursor].maxRenderIndex = indexCursor;
                                 ThrottleGraph[CurrentLapCursor].label = lapNumberLabel;
 
                                 MainViewModel.CurrentTelemetry.LapNumber = currentLapData.CurrentLapNum;
@@ -177,7 +177,7 @@ namespace F1Telemetry.WPF
                                 MainViewModel.CurrentTelemetry.Speed = currentTelemetry.Speed;
                                 MainViewModel.CurrentTelemetry.LapTime = currentLapData.CurrentLapTime;
 
-                                cursor++;
+                                indexCursor++;
                             }
                         }
                     });

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -113,9 +113,9 @@ namespace F1Telemetry.WPF
                         foreach (var lapModel in MainViewModel.LapData)
                         {
                             lapModel.Clear();
-                            cursor = 0;
-                            currentRenderPosition[0] = 0.0;
                         }
+
+                        ResetRenderCursor();
 
                         manager.GetPlayerInfo().NewLap += (s, e) =>
                         {

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -31,7 +31,7 @@ namespace F1Telemetry.WPF
         private PlottableSignalXY[] BrakeGraph = new PlottableSignalXY[3];
         private PlottableSignalXY[] GearGraph = new PlottableSignalXY[3];
 
-        private int currentLapCursor;
+        private int CurrentLapCursor;
 
         public MainWindow()
         {
@@ -110,7 +110,7 @@ namespace F1Telemetry.WPF
                         manager.GetPlayerInfo().NewLap += (s, e) =>
                         {
                             cursor = 0;
-                            currentLapCursor = (currentLapCursor + 1) % MainViewModel.LapData.Length;
+                            CurrentLapCursor = (CurrentLapCursor + 1) % MainViewModel.LapData.Length;
                         };
                     }
                 };
@@ -137,7 +137,7 @@ namespace F1Telemetry.WPF
                             {
                                 currentRenderPosition[0] = currentLapTime.LapDistance;
 
-                                var currentLap = MainViewModel.LapData[currentLapCursor];
+                                var currentLap = MainViewModel.LapData[CurrentLapCursor];
                                 var lapNumberLabel = $"Lap {currentLapTime.CurrentLapNum}";
 
                                 currentLap.Speed[cursor] = currentTelemetry.Speed;
@@ -147,17 +147,17 @@ namespace F1Telemetry.WPF
                                 currentLap.Throttle[cursor] = currentTelemetry.Throttle;
                                 currentLap.Brake[cursor] = currentTelemetry.Brake;
 
-                                SpeedGraph[currentLapCursor].maxRenderIndex = cursor;
-                                SpeedGraph[currentLapCursor].label = lapNumberLabel;
+                                SpeedGraph[CurrentLapCursor].maxRenderIndex = cursor;
+                                SpeedGraph[CurrentLapCursor].label = lapNumberLabel;
 
-                                GearGraph[currentLapCursor].maxRenderIndex = cursor;
-                                GearGraph[currentLapCursor].label = lapNumberLabel;
+                                GearGraph[CurrentLapCursor].maxRenderIndex = cursor;
+                                GearGraph[CurrentLapCursor].label = lapNumberLabel;
 
-                                BrakeGraph[currentLapCursor].maxRenderIndex = cursor;
-                                BrakeGraph[currentLapCursor].label = lapNumberLabel;
+                                BrakeGraph[CurrentLapCursor].maxRenderIndex = cursor;
+                                BrakeGraph[CurrentLapCursor].label = lapNumberLabel;
 
-                                ThrottleGraph[currentLapCursor].maxRenderIndex = cursor;
-                                ThrottleGraph[currentLapCursor].label = lapNumberLabel;
+                                ThrottleGraph[CurrentLapCursor].maxRenderIndex = cursor;
+                                ThrottleGraph[CurrentLapCursor].label = lapNumberLabel;
 
                                 MainViewModel.CurrentTelemetry.Brake = currentTelemetry.Brake;
                                 MainViewModel.CurrentTelemetry.Throttle = currentTelemetry.Throttle;

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -49,8 +49,8 @@ namespace F1Telemetry.WPF
                 GearGraphPlot.plt.PlotBar(currentRenderPosition, currentRenderValue);
                 GearGraphPlot.plt.YLabel("Gear");
 
-                BrakeGraph = BrakeGraphPlot.plt.PlotSignalXY(lap.Distance, lap.Brake, color: Color.Red);
-                ThrottleGraph = ThrottleGraphPlot.plt.PlotSignalXY(lap.Distance, lap.Throttle, color: Color.Green);
+                BrakeGraph = BrakeGraphPlot.plt.PlotSignalXY(lap.Distance, lap.Brake);
+                ThrottleGraph = ThrottleGraphPlot.plt.PlotSignalXY(lap.Distance, lap.Throttle);
 
                 BrakeGraphPlot.plt.PlotBar(currentRenderPosition, currentRenderValue);
                 ThrottleGraphPlot.plt.PlotBar(currentRenderPosition, currentRenderValue);

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -31,6 +31,9 @@ namespace F1Telemetry.WPF
         private PlottableSignalXY[] BrakeGraph = new PlottableSignalXY[3];
         private PlottableSignalXY[] GearGraph = new PlottableSignalXY[3];
 
+        /// <summary>
+        /// The current lap cursor for the array.
+        /// </summary>
         private int CurrentLapCursor;
 
         public MainWindow()

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -31,6 +31,7 @@ namespace F1Telemetry.WPF
         private CancellationTokenSource ListeningCancellationTokenSource;
         private PlottableSignalXY SpeedGraph;
         private PlottableSignalXY ThrottleGraph;
+        private int currentLapCursor;
 
         public MainWindow()
         {
@@ -38,27 +39,30 @@ namespace F1Telemetry.WPF
 
             DataContext = MainViewModel;
 
-            SpeedGraph = SpeedGraphPlot.plt.PlotSignalXY(MainViewModel.time, MainViewModel.speed);
-            SpeedGraphPlot.plt.PlotBar(currentRenderPosition, currentRenderValue);
-            SpeedGraphPlot.plt.YLabel("Speed");
+            foreach (var lap in MainViewModel.LapData)
+            { 
+                SpeedGraph = SpeedGraphPlot.plt.PlotSignalXY(lap.Distance, lap.Speed);
+                SpeedGraphPlot.plt.PlotBar(currentRenderPosition, currentRenderValue);
+                SpeedGraphPlot.plt.YLabel("Speed");
 
-            GearGraph = GearGraphPlot.plt.PlotSignalXY(MainViewModel.time, MainViewModel.gear);
-            GearGraphPlot.plt.PlotBar(currentRenderPosition, currentRenderValue);
-            GearGraphPlot.plt.YLabel("Gear");
+                GearGraph = GearGraphPlot.plt.PlotSignalXY(lap.Distance, lap.Gear);
+                GearGraphPlot.plt.PlotBar(currentRenderPosition, currentRenderValue);
+                GearGraphPlot.plt.YLabel("Gear");
 
-            BrakeGraph = BrakeGraphPlot.plt.PlotSignalXY(MainViewModel.time, MainViewModel.brake, color: Color.Red);
-            ThrottleGraph = ThrottleGraphPlot.plt.PlotSignalXY(MainViewModel.time, MainViewModel.throttle, color: Color.Green);
+                BrakeGraph = BrakeGraphPlot.plt.PlotSignalXY(lap.Distance, lap.Brake, color: Color.Red);
+                ThrottleGraph = ThrottleGraphPlot.plt.PlotSignalXY(lap.Distance, lap.Throttle, color: Color.Green);
 
-            BrakeGraphPlot.plt.PlotBar(currentRenderPosition, currentRenderValue);
-            ThrottleGraphPlot.plt.PlotBar(currentRenderPosition, currentRenderValue);
+                BrakeGraphPlot.plt.PlotBar(currentRenderPosition, currentRenderValue);
+                ThrottleGraphPlot.plt.PlotBar(currentRenderPosition, currentRenderValue);
 
-            SpeedGraphPlot.plt.Axis(0, 6000, 0, 360);
-            GearGraphPlot.plt.Axis(0, 6000, 0, 9);
+                SpeedGraphPlot.plt.Axis(0, 6000, 0, 360);
+                GearGraphPlot.plt.Axis(0, 6000, 0, 9);
 
-            ThrottleGraphPlot.plt.Axis(0, 6000, 0, 1.05);
-            ThrottleGraphPlot.plt.YLabel("Throttle");
-            BrakeGraphPlot.plt.Axis(0, 6000, 0, 1.05);
-            BrakeGraphPlot.plt.YLabel("Brake");
+                ThrottleGraphPlot.plt.Axis(0, 6000, 0, 1.05);
+                ThrottleGraphPlot.plt.YLabel("Throttle");
+                BrakeGraphPlot.plt.Axis(0, 6000, 0, 1.05);
+                BrakeGraphPlot.plt.YLabel("Brake");
+            }
 
             GraphRenderTimer.Interval = TimeSpan.FromMilliseconds(20);
             GraphRenderTimer.Tick += (s, e) =>
@@ -101,6 +105,7 @@ namespace F1Telemetry.WPF
                         manager.GetPlayerInfo().NewLap += (s, e) =>
                         {
                             cursor = 0;
+                            currentLapCursor = (currentLapCursor + 1) % MainViewModel.LapData.Length;
                         };
                     }
                 };
@@ -127,12 +132,14 @@ namespace F1Telemetry.WPF
                             {
                                 currentRenderPosition[0] = currentLapTime.LapDistance;
 
-                                MainViewModel.speed[cursor] = currentTelemetry.Speed;
-                                MainViewModel.time[cursor] = currentLapTime.LapDistance;
-                                MainViewModel.gear[cursor] = currentTelemetry.Gear;
+                                var currentLap = MainViewModel.LapData[currentLapCursor];
 
-                                MainViewModel.throttle[cursor] = currentTelemetry.Throttle;
-                                MainViewModel.brake[cursor] = currentTelemetry.Brake;
+                                currentLap.Speed[cursor] = currentTelemetry.Speed;
+                                currentLap.Distance[cursor] = currentLapTime.LapDistance;
+                                currentLap.Gear[cursor] = currentTelemetry.Gear;
+
+                                currentLap.Throttle[cursor] = currentTelemetry.Throttle;
+                                currentLap.Brake[cursor] = currentTelemetry.Brake;
 
                                 SpeedGraph.maxRenderIndex = cursor;
                                 GearGraph.maxRenderIndex = cursor;

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -1,11 +1,9 @@
 ﻿using F12020Telemetry;
 using F12020Telemetry.Data;
 using F12020Telemetry.Util.Extensions;
-using F1Telemetry.WPF.Model;
 using F1Telemetry.WPF.ViewModels;
 using ScottPlot;
 using System;
-using System.Drawing;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
@@ -22,15 +20,17 @@ namespace F1Telemetry.WPF
     /// </summary>
     public partial class MainWindow : Window
     {
-        private PlottableSignalXY BrakeGraph;
         private double[] currentRenderPosition = new double[1] { 0 };
         private double[] currentRenderValue = new double[1] { 1000 };
-        private PlottableSignalXY GearGraph;
         private DispatcherTimer GraphRenderTimer = new DispatcherTimer();
         private bool IsListening;
         private CancellationTokenSource ListeningCancellationTokenSource;
-        private PlottableSignalXY SpeedGraph;
-        private PlottableSignalXY ThrottleGraph;
+
+        private PlottableSignalXY[] SpeedGraph = new PlottableSignalXY[3];
+        private PlottableSignalXY[] ThrottleGraph = new PlottableSignalXY[3];
+        private PlottableSignalXY[] BrakeGraph = new PlottableSignalXY[3];
+        private PlottableSignalXY[] GearGraph = new PlottableSignalXY[3];
+
         private int currentLapCursor;
 
         public MainWindow()
@@ -39,18 +39,18 @@ namespace F1Telemetry.WPF
 
             DataContext = MainViewModel;
 
-            foreach (var lap in MainViewModel.LapData)
-            { 
-                SpeedGraph = SpeedGraphPlot.plt.PlotSignalXY(lap.Distance, lap.Speed);
+            for (int i = 0; i < MainViewModel.LapData.Length; i++)
+            {
+                SpeedGraph[i] = SpeedGraphPlot.plt.PlotSignalXY(MainViewModel.LapData[i].Distance, MainViewModel.LapData[i].Speed);
                 SpeedGraphPlot.plt.PlotBar(currentRenderPosition, currentRenderValue);
                 SpeedGraphPlot.plt.YLabel("Speed");
 
-                GearGraph = GearGraphPlot.plt.PlotSignalXY(lap.Distance, lap.Gear);
+                GearGraph[i] = GearGraphPlot.plt.PlotSignalXY(MainViewModel.LapData[i].Distance, MainViewModel.LapData[i].Gear);
                 GearGraphPlot.plt.PlotBar(currentRenderPosition, currentRenderValue);
                 GearGraphPlot.plt.YLabel("Gear");
 
-                BrakeGraph = BrakeGraphPlot.plt.PlotSignalXY(lap.Distance, lap.Brake);
-                ThrottleGraph = ThrottleGraphPlot.plt.PlotSignalXY(lap.Distance, lap.Throttle);
+                BrakeGraph[i] = BrakeGraphPlot.plt.PlotSignalXY(MainViewModel.LapData[i].Distance, MainViewModel.LapData[i].Brake);
+                ThrottleGraph[i] = ThrottleGraphPlot.plt.PlotSignalXY(MainViewModel.LapData[i].Distance, MainViewModel.LapData[i].Throttle);
 
                 BrakeGraphPlot.plt.PlotBar(currentRenderPosition, currentRenderValue);
                 ThrottleGraphPlot.plt.PlotBar(currentRenderPosition, currentRenderValue);
@@ -141,11 +141,10 @@ namespace F1Telemetry.WPF
                                 currentLap.Throttle[cursor] = currentTelemetry.Throttle;
                                 currentLap.Brake[cursor] = currentTelemetry.Brake;
 
-                                SpeedGraph.maxRenderIndex = cursor;
-                                GearGraph.maxRenderIndex = cursor;
+                                SpeedGraph[currentLapCursor].maxRenderIndex = cursor;
 
-                                BrakeGraph.maxRenderIndex = cursor;
-                                ThrottleGraph.maxRenderIndex = cursor;
+                                BrakeGraph[currentLapCursor].maxRenderIndex = cursor;
+                                ThrottleGraph[currentLapCursor].maxRenderIndex = cursor;
 
                                 MainViewModel.CurrentTelemetry.Brake = currentTelemetry.Brake;
                                 MainViewModel.CurrentTelemetry.Throttle = currentTelemetry.Throttle;

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -128,27 +128,28 @@ namespace F1Telemetry.WPF
                         MainViewModel.SessionInfo.SessionType = telemetryManager.Session != null ? telemetryManager.Session.SessionType.GetDisplayName() : "";
 
                         var currentTelemetry = telemetryManager.GetPlayerInfo()?.CurrentTelemetry;
-                        var currentLapTime = telemetryManager.GetPlayerInfo()?.LapData.LastOrDefault();
+                        var currentLapData = telemetryManager.GetPlayerInfo()?.LapData.LastOrDefault();
 
                         if (currentTelemetry != null)
                         {
-                            if (currentLapTime.DriverStatus == DriverStatus.InGarage)
+                            if (currentLapData.DriverStatus == DriverStatus.InGarage)
                             {
                                 cursor = 0;
                             }
                             else
                             {
-                                currentRenderPosition[0] = currentLapTime.LapDistance;
+                                currentRenderPosition[0] = currentLapData.LapDistance;
 
-                                var currentLap = MainViewModel.LapData[CurrentLapCursor];
-                                var lapNumberLabel = $"Lap {currentLapTime.CurrentLapNum}";
+                                var currentLapDataModel = MainViewModel.LapData[CurrentLapCursor];
 
-                                currentLap.Speed[cursor] = currentTelemetry.Speed;
-                                currentLap.Distance[cursor] = currentLapTime.LapDistance;
-                                currentLap.Gear[cursor] = currentTelemetry.Gear;
+                                var lapNumberLabel = $"Lap {currentLapData.CurrentLapNum}";
 
-                                currentLap.Throttle[cursor] = currentTelemetry.Throttle;
-                                currentLap.Brake[cursor] = currentTelemetry.Brake;
+                                currentLapDataModel.Speed[cursor] = currentTelemetry.Speed;
+                                currentLapDataModel.Distance[cursor] = currentLapData.LapDistance;
+                                currentLapDataModel.Gear[cursor] = currentTelemetry.Gear;
+
+                                currentLapDataModel.Throttle[cursor] = currentTelemetry.Throttle;
+                                currentLapDataModel.Brake[cursor] = currentTelemetry.Brake;
 
                                 SpeedGraph[CurrentLapCursor].maxRenderIndex = cursor;
                                 SpeedGraph[CurrentLapCursor].label = lapNumberLabel;
@@ -166,7 +167,7 @@ namespace F1Telemetry.WPF
                                 MainViewModel.CurrentTelemetry.Throttle = currentTelemetry.Throttle;
                                 MainViewModel.CurrentTelemetry.EngineRPM = currentTelemetry.EngineRPM;
                                 MainViewModel.CurrentTelemetry.Speed = currentTelemetry.Speed;
-                                MainViewModel.CurrentTelemetry.LapTime = currentLapTime.CurrentLapTime;
+                                MainViewModel.CurrentTelemetry.LapTime = currentLapData.CurrentLapTime;
 
                                 cursor++;
                             }

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using F12020Telemetry;
 using F12020Telemetry.Data;
 using F12020Telemetry.Util.Extensions;
+using F1Telemetry.WPF.Model;
 using F1Telemetry.WPF.ViewModels;
 using ScottPlot;
 using System;

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -163,6 +163,7 @@ namespace F1Telemetry.WPF
                                 ThrottleGraph[CurrentLapCursor].maxRenderIndex = cursor;
                                 ThrottleGraph[CurrentLapCursor].label = lapNumberLabel;
 
+                                MainViewModel.CurrentTelemetry.LapNumber = currentLapData.CurrentLapNum;
                                 MainViewModel.CurrentTelemetry.Brake = currentTelemetry.Brake;
                                 MainViewModel.CurrentTelemetry.Throttle = currentTelemetry.Throttle;
                                 MainViewModel.CurrentTelemetry.EngineRPM = currentTelemetry.EngineRPM;

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -119,7 +119,7 @@ namespace F1Telemetry.WPF
 
                         manager.GetPlayerInfo().NewLap += (s, e) =>
                         {
-                            cursor = 0;
+                            ResetRenderCursor();
                             CurrentLapCursor = (CurrentLapCursor + 1) % MainViewModel.LapData.Length;
                         };
                     }
@@ -217,6 +217,11 @@ namespace F1Telemetry.WPF
 
                 ListenButton.Content = "Start Listening";
             }
+        }
+
+        private void ResetRenderCursor()
+        {
+            currentRenderPosition[0] = 0.0;
         }
     }
 }

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -44,10 +44,12 @@ namespace F1Telemetry.WPF
                 SpeedGraph[i] = SpeedGraphPlot.plt.PlotSignalXY(MainViewModel.LapData[i].Distance, MainViewModel.LapData[i].Speed);
                 SpeedGraphPlot.plt.PlotBar(currentRenderPosition, currentRenderValue);
                 SpeedGraphPlot.plt.YLabel("Speed");
+                SpeedGraphPlot.plt.Legend();
 
                 GearGraph[i] = GearGraphPlot.plt.PlotSignalXY(MainViewModel.LapData[i].Distance, MainViewModel.LapData[i].Gear);
                 GearGraphPlot.plt.PlotBar(currentRenderPosition, currentRenderValue);
                 GearGraphPlot.plt.YLabel("Gear");
+                GearGraphPlot.plt.Legend();
 
                 BrakeGraph[i] = BrakeGraphPlot.plt.PlotSignalXY(MainViewModel.LapData[i].Distance, MainViewModel.LapData[i].Brake);
                 ThrottleGraph[i] = ThrottleGraphPlot.plt.PlotSignalXY(MainViewModel.LapData[i].Distance, MainViewModel.LapData[i].Throttle);
@@ -60,8 +62,11 @@ namespace F1Telemetry.WPF
 
                 ThrottleGraphPlot.plt.Axis(0, 6000, 0, 1.05);
                 ThrottleGraphPlot.plt.YLabel("Throttle");
+                ThrottleGraphPlot.plt.Legend();
+
                 BrakeGraphPlot.plt.Axis(0, 6000, 0, 1.05);
                 BrakeGraphPlot.plt.YLabel("Brake");
+                BrakeGraphPlot.plt.Legend();
             }
 
             GraphRenderTimer.Interval = TimeSpan.FromMilliseconds(20);
@@ -133,6 +138,7 @@ namespace F1Telemetry.WPF
                                 currentRenderPosition[0] = currentLapTime.LapDistance;
 
                                 var currentLap = MainViewModel.LapData[currentLapCursor];
+                                var lapNumberLabel = $"Lap {currentLapTime.CurrentLapNum}";
 
                                 currentLap.Speed[cursor] = currentTelemetry.Speed;
                                 currentLap.Distance[cursor] = currentLapTime.LapDistance;
@@ -142,9 +148,16 @@ namespace F1Telemetry.WPF
                                 currentLap.Brake[cursor] = currentTelemetry.Brake;
 
                                 SpeedGraph[currentLapCursor].maxRenderIndex = cursor;
+                                SpeedGraph[currentLapCursor].label = lapNumberLabel;
+
+                                GearGraph[currentLapCursor].maxRenderIndex = cursor;
+                                GearGraph[currentLapCursor].label = lapNumberLabel;
 
                                 BrakeGraph[currentLapCursor].maxRenderIndex = cursor;
+                                BrakeGraph[currentLapCursor].label = lapNumberLabel;
+
                                 ThrottleGraph[currentLapCursor].maxRenderIndex = cursor;
+                                ThrottleGraph[currentLapCursor].label = lapNumberLabel;
 
                                 MainViewModel.CurrentTelemetry.Brake = currentTelemetry.Brake;
                                 MainViewModel.CurrentTelemetry.Throttle = currentTelemetry.Throttle;

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -121,6 +121,7 @@ namespace F1Telemetry.WPF
                         {
                             ResetRenderCursor();
                             CurrentLapCursor = (CurrentLapCursor + 1) % MainViewModel.LapData.Length;
+                            indexCursor = 0;
                         };
                     }
                 };

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -110,6 +110,13 @@ namespace F1Telemetry.WPF
                         ThrottleGraphPlot.plt.Axis(0, manager.Session.TrackLength, 0, 1.05);
                         BrakeGraphPlot.plt.Axis(0, manager.Session.TrackLength, 0, 1.05);
 
+                        foreach (var lapModel in MainViewModel.LapData)
+                        {
+                            lapModel.Clear();
+                            cursor = 0;
+                            currentRenderPosition[0] = 0.0;
+                        }
+
                         manager.GetPlayerInfo().NewLap += (s, e) =>
                         {
                             cursor = 0;

--- a/F1Telemetry.WPF/Model/CurrentLapDataModel.cs
+++ b/F1Telemetry.WPF/Model/CurrentLapDataModel.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace F1Telemetry.WPF.Model
 {
@@ -17,5 +15,17 @@ namespace F1Telemetry.WPF.Model
 
         public double[] Throttle = new double[25_000];
         public double[] Brake = new double[25_000];
+
+        /// <summary>
+        /// Clears this instance.
+        /// </summary>
+        public void Clear()
+        {
+            Array.Clear(Speed, 0, Speed.Length);
+            Array.Clear(Distance, 0, Speed.Length);
+            Array.Clear(Gear, 0, Speed.Length);
+            Array.Clear(Throttle, 0, Speed.Length);
+            Array.Clear(Brake, 0, Speed.Length);
+        }
     }
 }

--- a/F1Telemetry.WPF/Model/CurrentLapDataModel.cs
+++ b/F1Telemetry.WPF/Model/CurrentLapDataModel.cs
@@ -4,6 +4,9 @@ using System.Text;
 
 namespace F1Telemetry.WPF.Model
 {
+    /// <summary>
+    /// Contains the lap data series for one lap.
+    /// </summary>
     public class CurrentLapDataModel
     {
         // 5000 for one minute of data.

--- a/F1Telemetry.WPF/Model/CurrentLapDataModel.cs
+++ b/F1Telemetry.WPF/Model/CurrentLapDataModel.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace F1Telemetry.WPF.Model
+{
+    public class CurrentLapDataModel
+    {
+        // 5000 for one minute of data.
+        public double[] Speed = new double[25_000];
+
+        public double[] Distance = new double[25_000];
+        public double[] Gear = new double[25_000];
+
+        public double[] Throttle = new double[25_000];
+        public double[] Brake = new double[25_000];
+    }
+}

--- a/F1Telemetry.WPF/Model/CurrentTelemetryDataModel.cs
+++ b/F1Telemetry.WPF/Model/CurrentTelemetryDataModel.cs
@@ -1,8 +1,8 @@
 ﻿using System.ComponentModel;
 
-namespace F1Telemetry.WPF.ViewModels
+namespace F1Telemetry.WPF.Model
 {
-    public class CurrentTelemetryDataViewModel : INotifyPropertyChanged
+    public class CurrentTelemetryDataModel : INotifyPropertyChanged
     {
         public float Brake { get; set; }
         public float Throttle { get; set; }

--- a/F1Telemetry.WPF/Model/CurrentTelemetryDataModel.cs
+++ b/F1Telemetry.WPF/Model/CurrentTelemetryDataModel.cs
@@ -8,6 +8,7 @@ namespace F1Telemetry.WPF.Model
     /// <seealso cref="System.ComponentModel.INotifyPropertyChanged" />
     public class CurrentTelemetryDataModel : INotifyPropertyChanged
     {
+        public int LapNumber { get; set; }
         public float Brake { get; set; }
         public float Throttle { get; set; }
         public ushort EngineRPM { get; set; }

--- a/F1Telemetry.WPF/Model/CurrentTelemetryDataModel.cs
+++ b/F1Telemetry.WPF/Model/CurrentTelemetryDataModel.cs
@@ -2,6 +2,10 @@
 
 namespace F1Telemetry.WPF.Model
 {
+    /// <summary>
+    /// Contains the data for the current condition/telemetry of the car.
+    /// </summary>
+    /// <seealso cref="System.ComponentModel.INotifyPropertyChanged" />
     public class CurrentTelemetryDataModel : INotifyPropertyChanged
     {
         public float Brake { get; set; }

--- a/F1Telemetry.WPF/ViewModels/MainViewModel.cs
+++ b/F1Telemetry.WPF/ViewModels/MainViewModel.cs
@@ -1,5 +1,5 @@
 ﻿using F1Telemetry.WPF.Command;
-using System;
+using F1Telemetry.WPF.Model;
 using System.ComponentModel;
 
 namespace F1Telemetry.WPF.ViewModels
@@ -17,7 +17,7 @@ namespace F1Telemetry.WPF.ViewModels
         public double[] throttle = new double[25_000];
         public double[] brake = new double[25_000];
 
-        public CurrentTelemetryDataViewModel CurrentTelemetry { get; set; } = new CurrentTelemetryDataViewModel();
+        public CurrentTelemetryDataModel CurrentTelemetry { get; set; } = new CurrentTelemetryDataModel();
 
         public event PropertyChangedEventHandler PropertyChanged;
 

--- a/F1Telemetry.WPF/ViewModels/MainViewModel.cs
+++ b/F1Telemetry.WPF/ViewModels/MainViewModel.cs
@@ -8,15 +8,7 @@ namespace F1Telemetry.WPF.ViewModels
     {
         public SessionViewModel SessionInfo { get; set; } = new SessionViewModel();
 
-        // 5000 for one minute of data.
-        public double[] speed = new double[25_000];
-
-        public double[] time = new double[25_000];
-        public double[] gear = new double[25_000];
-
-        public double[] throttle = new double[25_000];
-        public double[] brake = new double[25_000];
-
+        public CurrentLapDataModel[] LapData { get; } = new CurrentLapDataModel[3];
         public CurrentTelemetryDataModel CurrentTelemetry { get; set; } = new CurrentTelemetryDataModel();
 
         public event PropertyChangedEventHandler PropertyChanged;
@@ -33,6 +25,10 @@ namespace F1Telemetry.WPF.ViewModels
         public MainViewModel()
         {
             SetTopmostCommand = new RelayCommand<bool>(SetTopmost);
+            for (int i = 0; i < LapData.Length; i++)
+            {
+                LapData[i] = new CurrentLapDataModel();
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds 
- The support of recording three laps in the live telemetry.
- Live current lap number.

<img width="662" alt="Annotation 2020-08-07 130308" src="https://user-images.githubusercontent.com/9620862/89634116-f4df8600-d8f8-11ea-8f61-9f3d7b049bea.png">

<img width="675" alt="Annotation 2020-08-07 130332" src="https://user-images.githubusercontent.com/9620862/89634126-f8730d00-d8f8-11ea-9d6c-8bdb71c415e5.png">

