### PR TITLE
#26 Enable Lap Data Selection

### DIFF
--- a/F1Telemetry.Core/Util/Extensions/CarTelemetryDataExtensions.cs
+++ b/F1Telemetry.Core/Util/Extensions/CarTelemetryDataExtensions.cs
@@ -9,10 +9,11 @@ namespace F1Telemetry.Core.Util.Extensions
         public static IEnumerable<CarTelemetryData> GetForLap(this IList<CarTelemetryData> carTelemetryData, IEnumerable<LapData> lapData)
         {
             var lapCarTelemetryData = new List<CarTelemetryData>();
+            var carTelemDataCopy = carTelemetryData.ToArray();
 
             foreach (var lastLap in lapData)
             {
-                lapCarTelemetryData.Add(carTelemetryData.SingleOrDefault(c => c.SessionTime.Equals(lastLap.SessionTime) && c.SessionUID.Equals(lastLap.SessionUID)));
+                lapCarTelemetryData.Add(carTelemDataCopy.SingleOrDefault(c => c.SessionTime.Equals(lastLap.SessionTime) && c.SessionUID.Equals(lastLap.SessionUID)));
             }
 
             return lapCarTelemetryData;

--- a/F1Telemetry.WPF/App.xaml
+++ b/F1Telemetry.WPF/App.xaml
@@ -2,7 +2,8 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:F1Telemetry.WPF"
-             StartupUri="MainWindow.xaml">
+             StartupUri="MainWindow.xaml"
+             ShutdownMode="OnMainWindowClose">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/F1Telemetry.WPF/Converter/ToggleLapCommandParamaterConverter.cs
+++ b/F1Telemetry.WPF/Converter/ToggleLapCommandParamaterConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Windows.Data;
+
+namespace F1Telemetry.WPF.Converter
+{
+    public class ToggleLapCommandParamaterConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            
+            return ((bool)values[0], (int)values[1]);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/F1Telemetry.WPF/MainWindow.xaml
+++ b/F1Telemetry.WPF/MainWindow.xaml
@@ -38,20 +38,22 @@
                 <ColumnDefinition  Width="30*" />
             </Grid.ColumnDefinitions>
 
-            <Grid.RowDefinitions>
-                <RowDefinition Height="3*" />
-                <RowDefinition Height="3*" />
-                <RowDefinition Height="3*" />
-                <RowDefinition Height="3*" />
-            </Grid.RowDefinitions>
-            <WpfPlot Name="SpeedGraphPlot" Grid.Column="0" />
-            <WpfPlot Name="ThrottleGraphPlot" Grid.Column="0" Grid.Row="1" />
-            <WpfPlot Name="BrakeGraphPlot" Grid.Column="0" Grid.Row="2" />
-            <WpfPlot Name="GearGraphPlot" Grid.Column="0" Grid.Row="3" />
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="3*" />
+                    <RowDefinition Height="3*" />
+                    <RowDefinition Height="3*" />
+                    <RowDefinition Height="3*" />
+                </Grid.RowDefinitions>
 
-            
-            <!--Car Info Panel--> 
-            
+                <WpfPlot Name="SpeedGraphPlot" Grid.Column="0" />
+                <WpfPlot Name="ThrottleGraphPlot" Grid.Column="0" Grid.Row="1" />
+                <WpfPlot Name="BrakeGraphPlot" Grid.Column="0" Grid.Row="2" />
+                <WpfPlot Name="GearGraphPlot" Grid.Column="0" Grid.Row="3" />
+            </Grid>
+
+            <!--Car Info Panel-->
+
             <StackPanel Grid.Column="1" Grid.RowSpan="2" DataContext="{Binding CurrentTelemetry}">
                 <TextBlock Margin="3" FontFamily="{StaticResource TitilliumBold}">Car Info</TextBlock>
                 <Grid>

--- a/F1Telemetry.WPF/MainWindow.xaml
+++ b/F1Telemetry.WPF/MainWindow.xaml
@@ -34,8 +34,8 @@
 
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition  Width="9*" />
-                <ColumnDefinition  Width="2*" />
+                <ColumnDefinition  Width="70*" />
+                <ColumnDefinition  Width="30*" />
             </Grid.ColumnDefinitions>
 
             <Grid.RowDefinitions>

--- a/F1Telemetry.WPF/MainWindow.xaml
+++ b/F1Telemetry.WPF/MainWindow.xaml
@@ -153,6 +153,10 @@
             <WrapPanel>
                 <CheckBox x:Name="TopmostCheckbox" Command="{Binding SetTopmostCommand}" CommandParameter="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" VerticalContentAlignment="Center" />
                 <Label Content="Keep window on top" />
+
+                <CheckBox x:Name="DisableLiveTelemetryCheckbox" IsChecked="{Binding IsLiveTelemetryEnabled}" Command="{Binding EnableLiveTelemetryCommand}" CommandParameter="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" VerticalContentAlignment="Center" />
+                <Label Content="Enable Live Telemetry" />
+                
             </WrapPanel>
             <Button x:Name="ListenButton"  FontWeight="Bold" Command="{Binding StartListeningCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Self}}" Content="Start Listening" />
         </StackPanel>

--- a/F1Telemetry.WPF/MainWindow.xaml
+++ b/F1Telemetry.WPF/MainWindow.xaml
@@ -53,89 +53,98 @@
             </Grid>
 
             <!--Car Info Panel-->
+            <Grid Grid.Column="2">
 
-            <StackPanel Grid.Column="1" Grid.RowSpan="2" DataContext="{Binding CurrentTelemetry}">
-                <TextBlock Margin="3" FontFamily="{StaticResource TitilliumBold}">Car Info</TextBlock>
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="1*" />
-                        <ColumnDefinition Width="1*" />
-                    </Grid.ColumnDefinitions>
-                    <StackPanel Grid.Column="0">
-                        <TextBlock Margin="3" Text="Lap:" />
-                        <TextBlock Margin="3" Text="Time:" />
-                        <TextBlock Margin="3" Text="Spd:" />
-                        <TextBlock Margin="3" Text="RPM:" />
-                        <TextBlock Margin="3" Text="Throttle:" />
-                        <TextBlock Margin="3" Text="Brake:" />
-                    </StackPanel>
-
-                    <StackPanel Grid.Column="1">
-                        <TextBlock Margin="3" Text="{Binding LapNumber, UpdateSourceTrigger=PropertyChanged}" />
-                        <TextBlock Margin="3" Text="{Binding LapTime, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ToLapTimeString}}" />
-                        <TextBlock Margin="3" Text="{Binding Speed, UpdateSourceTrigger=PropertyChanged}" />
-                        <TextBlock Margin="3" Text="{Binding EngineRPM, UpdateSourceTrigger=PropertyChanged}" />
-                        <TextBlock Margin="3" Text="{Binding Throttle, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ToPercentageConverter}}" />
-                        <ProgressBar Minimum="0" Maximum="1" Value="{Binding Throttle}" />
-                        <TextBlock Margin="3" Text="{Binding Brake, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ToPercentageConverter}}" />
-                        <ProgressBar Minimum="0" Maximum="1" Value="{Binding Brake}" Foreground="#FFF81010" />
-                    </StackPanel>
-                </Grid>
-            </StackPanel>
-
-            <!--Tyre info panel-->
-            <Grid Grid.Column="1" Grid.Row="2" DataContext="{Binding CurrentTelemetry}" Grid.RowSpan="2">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
+                
+                <StackPanel Grid.Column="1">
+                    <StackPanel Grid.Column="1" Grid.RowSpan="2" DataContext="{Binding CurrentTelemetry}">
+                        <TextBlock Margin="3" FontFamily="{StaticResource TitilliumBold}">Car Info</TextBlock>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="1*" />
+                                <ColumnDefinition Width="1*" />
+                            </Grid.ColumnDefinitions>
+                            <StackPanel Grid.Column="0">
+                                <TextBlock Margin="3" Text="Lap:" />
+                                <TextBlock Margin="3" Text="Time:" />
+                                <TextBlock Margin="3" Text="Spd:" />
+                                <TextBlock Margin="3" Text="RPM:" />
+                                <TextBlock Margin="3" Text="Throttle:" />
+                                <TextBlock Margin="3" Text="Brake:" />
+                            </StackPanel>
 
-                <StackPanel Grid.Column="0" TextElement.FontSize="11">
-                    <TextBlock Margin="3" FontFamily="{StaticResource TitilliumBold}">
+                            <StackPanel Grid.Column="1">
+                                <TextBlock Margin="3" Text="{Binding LapNumber, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBlock Margin="3" Text="{Binding LapTime, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ToLapTimeString}}" />
+                                <TextBlock Margin="3" Text="{Binding Speed, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBlock Margin="3" Text="{Binding EngineRPM, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBlock Margin="3" Text="{Binding Throttle, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ToPercentageConverter}}" />
+                                <ProgressBar Minimum="0" Maximum="1" Value="{Binding Throttle}" />
+                                <TextBlock Margin="3" Text="{Binding Brake, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ToPercentageConverter}}" />
+                                <ProgressBar Minimum="0" Maximum="1" Value="{Binding Brake}" Foreground="#FFF81010" />
+                            </StackPanel>
+                        </Grid>
+                    </StackPanel>
+
+                    <!--Tyre info panel-->
+                    <Grid Grid.Column="1" Grid.Row="2" DataContext="{Binding CurrentTelemetry}" Grid.RowSpan="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <StackPanel Grid.Column="0" TextElement.FontSize="11">
+                            <TextBlock Margin="3" FontFamily="{StaticResource TitilliumBold}">
                             Tyre Info
-                    </TextBlock>
-                    <TextBlock Margin="3">Compound</TextBlock>
+                            </TextBlock>
+                            <TextBlock Margin="3">Compound</TextBlock>
 
-                    <TextBlock Margin="3">FL</TextBlock>
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="C:" Margin="3" />
-                        <TextBlock Name="FrontLeftCarcass" Margin="3" Text="{Binding TyreCarcassTemperature.FrontLeft.Current, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBlock Margin="3">FL</TextBlock>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="C:" Margin="3" />
+                                <TextBlock Name="FrontLeftCarcass" Margin="3" Text="{Binding TyreCarcassTemperature.FrontLeft.Current, UpdateSourceTrigger=PropertyChanged}" />
 
-                        <TextBlock Text="S:" Margin="3" />
-                        <TextBlock Name="FrontLeftSurface" Margin="3" Text="{Binding TyreSurfaceTemperature.FrontLeft.Current, UpdateSourceTrigger=PropertyChanged}" />
-                    </StackPanel>
+                                <TextBlock Text="S:" Margin="3" />
+                                <TextBlock Name="FrontLeftSurface" Margin="3" Text="{Binding TyreSurfaceTemperature.FrontLeft.Current, UpdateSourceTrigger=PropertyChanged}" />
+                            </StackPanel>
 
-                    <TextBlock Margin="3">RL</TextBlock>
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="C:" Margin="3" />
-                        <TextBlock Name="RearLeftCarcass" Margin="3" Text="{Binding TyreCarcassTemperature.RearLeft.Current, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBlock Margin="3">RL</TextBlock>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="C:" Margin="3" />
+                                <TextBlock Name="RearLeftCarcass" Margin="3" Text="{Binding TyreCarcassTemperature.RearLeft.Current, UpdateSourceTrigger=PropertyChanged}" />
 
-                        <TextBlock Text="S:" Margin="3" />
-                        <TextBlock Name="RearLeftSurface" Margin="3" Text="{Binding TyreSurfaceTemperature.RearLeft.Current, UpdateSourceTrigger=PropertyChanged}" />
-                    </StackPanel>
-                </StackPanel>
+                                <TextBlock Text="S:" Margin="3" />
+                                <TextBlock Name="RearLeftSurface" Margin="3" Text="{Binding TyreSurfaceTemperature.RearLeft.Current, UpdateSourceTrigger=PropertyChanged}" />
+                            </StackPanel>
+                        </StackPanel>
 
-                <StackPanel Grid.Column="1" TextElement.FontSize="11">
-                    <TextBlock Margin="3"></TextBlock>
-                    <TextBlock Margin="3" Text="{Binding TyreCompound}" />
+                        <StackPanel Grid.Column="1" TextElement.FontSize="11">
+                            <TextBlock Margin="3"></TextBlock>
+                            <TextBlock Margin="3" Text="{Binding TyreCompound}" />
 
-                    <TextBlock Margin="3">FR</TextBlock>
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="C:" Margin="3" />
-                        <TextBlock Name="FrontRightCarcass" Margin="3" Text="{Binding TyreCarcassTemperature.FrontRight.Current, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBlock Margin="3">FR</TextBlock>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="C:" Margin="3" />
+                                <TextBlock Name="FrontRightCarcass" Margin="3" Text="{Binding TyreCarcassTemperature.FrontRight.Current, UpdateSourceTrigger=PropertyChanged}" />
 
-                        <TextBlock Text="S:" Margin="3" />
-                        <TextBlock Name="FrontRightSurface" Margin="3" Text="{Binding TyreSurfaceTemperature.FrontRight.Current, UpdateSourceTrigger=PropertyChanged}" />
-                    </StackPanel>
+                                <TextBlock Text="S:" Margin="3" />
+                                <TextBlock Name="FrontRightSurface" Margin="3" Text="{Binding TyreSurfaceTemperature.FrontRight.Current, UpdateSourceTrigger=PropertyChanged}" />
+                            </StackPanel>
 
-                    <TextBlock Margin="3">RR</TextBlock>
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="C:" Margin="3" />
-                        <TextBlock Name="RearRightCarcass" Margin="3" Text="{Binding TyreCarcassTemperature.RearRight.Current, UpdateSourceTrigger=PropertyChanged}" />
+                            <TextBlock Margin="3">RR</TextBlock>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="C:" Margin="3" />
+                                <TextBlock Name="RearRightCarcass" Margin="3" Text="{Binding TyreCarcassTemperature.RearRight.Current, UpdateSourceTrigger=PropertyChanged}" />
 
-                        <TextBlock Text="S:" Margin="3" />
-                        <TextBlock Name="RearRightSurface" Margin="3" Text="{Binding TyreSurfaceTemperature.RearRight.Current, UpdateSourceTrigger=PropertyChanged}" />
-                    </StackPanel>
+                                <TextBlock Text="S:" Margin="3" />
+                                <TextBlock Name="RearRightSurface" Margin="3" Text="{Binding TyreSurfaceTemperature.RearRight.Current, UpdateSourceTrigger=PropertyChanged}" />
+                            </StackPanel>
+                        </StackPanel>
+                    </Grid>
                 </StackPanel>
             </Grid>
         </Grid>

--- a/F1Telemetry.WPF/MainWindow.xaml
+++ b/F1Telemetry.WPF/MainWindow.xaml
@@ -1,15 +1,18 @@
-﻿<Window x:Class="F1Telemetry.WPF.MainWindow"
+﻿<Window
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:local="clr-namespace:F1Telemetry.WPF.Converter" xmlns:viewmodels="clr-namespace:F1Telemetry.WPF.ViewModels"
+        xmlns:sys="clr-namespace:System;assembly=mscorlib"
         xmlns:core="clr-namespace:F1Telemetry.Core.Data;assembly=F1Telemetry.Core"
+        x:Name="window" x:Class="F1Telemetry.WPF.MainWindow"
         mc:Ignorable="d"
         Title="F1 Telemetry" Height="550" Width="900" Topmost="{Binding IsTopmost}">
 
     <Window.Resources>
         <local:ToPercentageConverter x:Key="ToPercentageConverter" />
         <local:ToLapTimeString x:Key="ToLapTimeString" />
+        <local:ToggleLapCommandParamaterConverter x:Key="ToggleLapCommandParameterConverter" />
     </Window.Resources>
 
     <Window.DataContext>
@@ -46,10 +49,10 @@
                     <RowDefinition Height="3*" />
                 </Grid.RowDefinitions>
 
-                <WpfPlot Name="SpeedGraphPlot" Grid.Column="0" />
-                <WpfPlot Name="ThrottleGraphPlot" Grid.Column="0" Grid.Row="1" />
-                <WpfPlot Name="BrakeGraphPlot" Grid.Column="0" Grid.Row="2" />
-                <WpfPlot Name="GearGraphPlot" Grid.Column="0" Grid.Row="3" />
+                <WpfPlot x:Name="SpeedGraphPlot" Grid.Column="0" />
+                <WpfPlot x:Name="ThrottleGraphPlot" Grid.Column="0" Grid.Row="1" />
+                <WpfPlot x:Name="BrakeGraphPlot" Grid.Column="0" Grid.Row="2" />
+                <WpfPlot x:Name="GearGraphPlot" Grid.Column="0" Grid.Row="3" />
             </Grid>
 
             <!--Car Info Panel-->
@@ -59,10 +62,49 @@
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
-                
+
+                <ListView x:Name="lapLeaderboard" ItemsSource="{Binding LapSummaries}">
+                    <ListView.View>
+                        <GridView>
+                            <GridViewColumn Header="" Width="{x:Static sys:Double.NaN}">
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <Grid>
+                                            <CheckBox Command="{Binding DataContext.ToggleToGraphCommand, ElementName=window, Mode=OneWay}">
+                                                <CheckBox.CommandParameter>
+                                                    <MultiBinding Converter="{StaticResource ToggleLapCommandParameterConverter}">
+                                                        <MultiBinding.Bindings>
+                                                            <Binding Path="IsChecked">
+                                                                <Binding.RelativeSource>
+                                                                    <RelativeSource>
+                                                                        <RelativeSource.Mode>Self</RelativeSource.Mode>
+                                                                    </RelativeSource>
+                                                                </Binding.RelativeSource>
+                                                            </Binding>
+                                                            <Binding Path="LapNumber" />
+                                                        </MultiBinding.Bindings>
+                                                    </MultiBinding>
+                                                </CheckBox.CommandParameter>
+                                            </CheckBox>
+                                        </Grid>
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                            <GridViewColumn Header="Lap" DisplayMemberBinding="{Binding LapNumber}" Width="{x:Static sys:Double.NaN}" />
+                            <GridViewColumn Header="Time" Width="{x:Static sys:Double.NaN}">
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding LapTime, Converter={StaticResource ToLapTimeString}}" />
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                        </GridView>
+                    </ListView.View>
+                </ListView>
+
                 <StackPanel Grid.Column="1">
                     <StackPanel Grid.Column="1" Grid.RowSpan="2" DataContext="{Binding CurrentTelemetry}">
-                        <TextBlock Margin="3" FontFamily="{StaticResource TitilliumBold}">Car Info</TextBlock>
+                        <TextBlock Margin="3" FontFamily="{StaticResource TitilliumBold}"><Run Text="Car Info" /></TextBlock>
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="1*" />
@@ -79,12 +121,12 @@
 
                             <StackPanel Grid.Column="1">
                                 <TextBlock Margin="3" Text="{Binding LapNumber, UpdateSourceTrigger=PropertyChanged}" />
-                                <TextBlock Margin="3" Text="{Binding LapTime, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ToLapTimeString}}" />
+                                <TextBlock Margin="3" Text="{Binding LapTime, Converter={StaticResource ToLapTimeString}, UpdateSourceTrigger=PropertyChanged}" />
                                 <TextBlock Margin="3" Text="{Binding Speed, UpdateSourceTrigger=PropertyChanged}" />
                                 <TextBlock Margin="3" Text="{Binding EngineRPM, UpdateSourceTrigger=PropertyChanged}" />
-                                <TextBlock Margin="3" Text="{Binding Throttle, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ToPercentageConverter}}" />
+                                <TextBlock Margin="3" Text="{Binding Throttle, Converter={StaticResource ToPercentageConverter}, UpdateSourceTrigger=PropertyChanged}" />
                                 <ProgressBar Minimum="0" Maximum="1" Value="{Binding Throttle}" />
-                                <TextBlock Margin="3" Text="{Binding Brake, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource ToPercentageConverter}}" />
+                                <TextBlock Margin="3" Text="{Binding Brake, Converter={StaticResource ToPercentageConverter}, UpdateSourceTrigger=PropertyChanged}" />
                                 <ProgressBar Minimum="0" Maximum="1" Value="{Binding Brake}" Foreground="#FFF81010" />
                             </StackPanel>
                         </Grid>
@@ -98,50 +140,48 @@
                         </Grid.ColumnDefinitions>
 
                         <StackPanel Grid.Column="0" TextElement.FontSize="11">
-                            <TextBlock Margin="3" FontFamily="{StaticResource TitilliumBold}">
-                            Tyre Info
-                            </TextBlock>
-                            <TextBlock Margin="3">Compound</TextBlock>
+                            <TextBlock Margin="3" FontFamily="{StaticResource TitilliumBold}"><Run Text="Tyre Info" /></TextBlock>
+                            <TextBlock Margin="3"><Run Text="Compound" /></TextBlock>
 
-                            <TextBlock Margin="3">FL</TextBlock>
+                            <TextBlock Margin="3"><Run Text="FL" /></TextBlock>
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="C:" Margin="3" />
-                                <TextBlock Name="FrontLeftCarcass" Margin="3" Text="{Binding TyreCarcassTemperature.FrontLeft.Current, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBlock x:Name="FrontLeftCarcass" Margin="3" Text="{Binding TyreCarcassTemperature.FrontLeft.Current, UpdateSourceTrigger=PropertyChanged}" />
 
                                 <TextBlock Text="S:" Margin="3" />
-                                <TextBlock Name="FrontLeftSurface" Margin="3" Text="{Binding TyreSurfaceTemperature.FrontLeft.Current, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBlock x:Name="FrontLeftSurface" Margin="3" Text="{Binding TyreSurfaceTemperature.FrontLeft.Current, UpdateSourceTrigger=PropertyChanged}" />
                             </StackPanel>
 
-                            <TextBlock Margin="3">RL</TextBlock>
+                            <TextBlock Margin="3"><Run Text="RL" /></TextBlock>
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="C:" Margin="3" />
-                                <TextBlock Name="RearLeftCarcass" Margin="3" Text="{Binding TyreCarcassTemperature.RearLeft.Current, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBlock x:Name="RearLeftCarcass" Margin="3" Text="{Binding TyreCarcassTemperature.RearLeft.Current, UpdateSourceTrigger=PropertyChanged}" />
 
                                 <TextBlock Text="S:" Margin="3" />
-                                <TextBlock Name="RearLeftSurface" Margin="3" Text="{Binding TyreSurfaceTemperature.RearLeft.Current, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBlock x:Name="RearLeftSurface" Margin="3" Text="{Binding TyreSurfaceTemperature.RearLeft.Current, UpdateSourceTrigger=PropertyChanged}" />
                             </StackPanel>
                         </StackPanel>
 
                         <StackPanel Grid.Column="1" TextElement.FontSize="11">
-                            <TextBlock Margin="3"></TextBlock>
+                            <TextBlock Margin="3" />
                             <TextBlock Margin="3" Text="{Binding TyreCompound}" />
 
-                            <TextBlock Margin="3">FR</TextBlock>
+                            <TextBlock Margin="3"><Run Text="FR" /></TextBlock>
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="C:" Margin="3" />
-                                <TextBlock Name="FrontRightCarcass" Margin="3" Text="{Binding TyreCarcassTemperature.FrontRight.Current, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBlock x:Name="FrontRightCarcass" Margin="3" Text="{Binding TyreCarcassTemperature.FrontRight.Current, UpdateSourceTrigger=PropertyChanged}" />
 
                                 <TextBlock Text="S:" Margin="3" />
-                                <TextBlock Name="FrontRightSurface" Margin="3" Text="{Binding TyreSurfaceTemperature.FrontRight.Current, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBlock x:Name="FrontRightSurface" Margin="3" Text="{Binding TyreSurfaceTemperature.FrontRight.Current, UpdateSourceTrigger=PropertyChanged}" />
                             </StackPanel>
 
-                            <TextBlock Margin="3">RR</TextBlock>
+                            <TextBlock Margin="3"><Run Text="RR" /></TextBlock>
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="C:" Margin="3" />
-                                <TextBlock Name="RearRightCarcass" Margin="3" Text="{Binding TyreCarcassTemperature.RearRight.Current, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBlock x:Name="RearRightCarcass" Margin="3" Text="{Binding TyreCarcassTemperature.RearRight.Current, UpdateSourceTrigger=PropertyChanged}" />
 
                                 <TextBlock Text="S:" Margin="3" />
-                                <TextBlock Name="RearRightSurface" Margin="3" Text="{Binding TyreSurfaceTemperature.RearRight.Current, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBlock x:Name="RearRightSurface" Margin="3" Text="{Binding TyreSurfaceTemperature.RearRight.Current, UpdateSourceTrigger=PropertyChanged}" />
                             </StackPanel>
                         </StackPanel>
                     </Grid>
@@ -151,12 +191,11 @@
 
         <StackPanel Grid.Row="2">
             <WrapPanel>
-                <CheckBox x:Name="TopmostCheckbox" Command="{Binding SetTopmostCommand}" CommandParameter="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" VerticalContentAlignment="Center" />
+                <CheckBox x:Name="TopmostCheckbox" Command="{Binding SetTopmostCommand}" CommandParameter="{Binding IsChecked, RelativeSource={RelativeSource Self}}" VerticalContentAlignment="Center" />
                 <Label Content="Keep window on top" />
 
-                <CheckBox x:Name="DisableLiveTelemetryCheckbox" IsChecked="{Binding IsLiveTelemetryEnabled}" Command="{Binding EnableLiveTelemetryCommand}" CommandParameter="{Binding Path=IsChecked, RelativeSource={RelativeSource Self}}" VerticalContentAlignment="Center" />
+                <CheckBox x:Name="DisableLiveTelemetryCheckbox" IsChecked="{Binding IsLiveTelemetryEnabled}" Command="{Binding EnableLiveTelemetryCommand}" CommandParameter="{Binding IsChecked, RelativeSource={RelativeSource Self}}" VerticalContentAlignment="Center" />
                 <Label Content="Enable Live Telemetry" />
-                
             </WrapPanel>
             <Button x:Name="ListenButton"  FontWeight="Bold" Command="{Binding StartListeningCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Self}}" Content="Start Listening" />
         </StackPanel>

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -23,6 +23,11 @@ namespace F1Telemetry.WPF
             BindGraphToViewModel();
             RegisterGraphRenderDispatcher();
 
+            MainViewModel.SpeedGraphPlot = SpeedGraphPlot;
+            MainViewModel.ThrottleGraphPlot = ThrottleGraphPlot;
+            MainViewModel.BrakeGraphPlot = BrakeGraphPlot;
+            MainViewModel.GearGraphPlot = GearGraphPlot;
+
             lapLeaderboard.ItemsSource = MainViewModel.LapSummaries;
 
             MainViewModel.Manager.NewSession += ManagerNewSession;

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using F1Telemetry.Core;
 using F1Telemetry.WPF.ViewModels;
-using F1Telemetry.WPF.Windows;
 using System;
 using System.Windows;
 

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -33,23 +33,21 @@ namespace F1Telemetry.WPF
         /// </summary>
         private void BindGraphToViewModel()
         {
+            BindCursorBar(); 
+
             for (int i = 0; i < MainViewModel.LapData.Length; i++)
             {
                 MainViewModel.SpeedGraph[i] = SpeedGraphPlot.plt.PlotSignalXY(MainViewModel.LapData[i].Distance, MainViewModel.LapData[i].Speed, lineWidth: DefaultLineWidth);
-                SpeedGraphPlot.plt.PlotBar(MainViewModel.CurrentRenderPosition, MainViewModel.CurrentRenderValue);
                 SpeedGraphPlot.plt.YLabel("Speed");
                 SpeedGraphPlot.plt.Legend();
 
                 MainViewModel.GearGraph[i] = GearGraphPlot.plt.PlotSignalXY(MainViewModel.LapData[i].Distance, MainViewModel.LapData[i].Gear, lineWidth: DefaultLineWidth);
-                GearGraphPlot.plt.PlotBar(MainViewModel.CurrentRenderPosition, MainViewModel.CurrentRenderValue);
+
                 GearGraphPlot.plt.YLabel("Gear");
                 GearGraphPlot.plt.Legend();
 
                 MainViewModel.BrakeGraph[i] = BrakeGraphPlot.plt.PlotSignalXY(MainViewModel.LapData[i].Distance, MainViewModel.LapData[i].Brake, lineWidth: DefaultLineWidth);
                 MainViewModel.ThrottleGraph[i] = ThrottleGraphPlot.plt.PlotSignalXY(MainViewModel.LapData[i].Distance, MainViewModel.LapData[i].Throttle, lineWidth: DefaultLineWidth);
-
-                BrakeGraphPlot.plt.PlotBar(MainViewModel.CurrentRenderPosition, MainViewModel.CurrentRenderValue);
-                ThrottleGraphPlot.plt.PlotBar(MainViewModel.CurrentRenderPosition, MainViewModel.CurrentRenderValue);
 
                 SpeedGraphPlot.plt.Axis(0, 6000, 0, 360);
                 GearGraphPlot.plt.Axis(0, 6000, 0, 9);
@@ -62,6 +60,14 @@ namespace F1Telemetry.WPF
                 BrakeGraphPlot.plt.YLabel("Brake");
                 BrakeGraphPlot.plt.Legend();
             }
+        }
+
+        private void BindCursorBar()
+        {
+            SpeedGraphPlot.plt.PlotBar(MainViewModel.CurrentRenderPosition, MainViewModel.CurrentRenderValue);
+            GearGraphPlot.plt.PlotBar(MainViewModel.CurrentRenderPosition, MainViewModel.CurrentRenderValue);
+            BrakeGraphPlot.plt.PlotBar(MainViewModel.CurrentRenderPosition, MainViewModel.CurrentRenderValue);
+            ThrottleGraphPlot.plt.PlotBar(MainViewModel.CurrentRenderPosition, MainViewModel.CurrentRenderValue);
         }
 
         private void RegisterGraphRenderDispatcher()

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -24,6 +24,8 @@ namespace F1Telemetry.WPF
             BindGraphToViewModel();
             RegisterGraphRenderDispatcher();
 
+            lapLeaderboard.ItemsSource = MainViewModel.LapSummaries;
+
             MainViewModel.Manager.NewSession += ManagerNewSession;
         }
 

--- a/F1Telemetry.WPF/MainWindow.xaml.cs
+++ b/F1Telemetry.WPF/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using F1Telemetry.Core;
 using F1Telemetry.WPF.ViewModels;
+using F1Telemetry.WPF.Windows;
 using System;
 using System.Windows;
 
@@ -33,7 +34,7 @@ namespace F1Telemetry.WPF
         /// </summary>
         private void BindGraphToViewModel()
         {
-            BindCursorBar(); 
+            BindCursorBar();
 
             for (int i = 0; i < MainViewModel.LapData.Length; i++)
             {

--- a/F1Telemetry.WPF/Model/LapSummaryModel.cs
+++ b/F1Telemetry.WPF/Model/LapSummaryModel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace F1Telemetry.WPF.Model
+{
+    public class LapSummaryModel
+    {
+        public int LapNumber { get; set; }
+        public float LapTime { get; set; }
+    }
+}

--- a/F1Telemetry.WPF/Styles/Window.xaml
+++ b/F1Telemetry.WPF/Styles/Window.xaml
@@ -1,5 +1,3 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:local="clr-namespace:F1Telemetry.WPF.Styles">
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
     
 </ResourceDictionary>

--- a/F1Telemetry.WPF/ViewModels/BaseViewModel.cs
+++ b/F1Telemetry.WPF/ViewModels/BaseViewModel.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel;
+
+namespace F1Telemetry.WPF.ViewModels
+{
+    /// <summary>
+    /// Base class for View Model.
+    /// </summary>
+    /// <seealso cref="System.ComponentModel.INotifyPropertyChanged" />
+    public class BaseViewModel : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+    }
+}

--- a/F1Telemetry.WPF/ViewModels/MainViewModel.cs
+++ b/F1Telemetry.WPF/ViewModels/MainViewModel.cs
@@ -23,6 +23,7 @@ namespace F1Telemetry.WPF.ViewModels
         public MainViewModel()
         {
             SetTopmostCommand = new RelayCommand<bool>(SetTopmost);
+            EnableLiveTelemetryCommand = new RelayCommand<bool>(EnableLiveTelemetry);
 
             for (int i = 0; i < LapData.Length; i++)
             {
@@ -43,6 +44,8 @@ namespace F1Telemetry.WPF.ViewModels
         public double[] CurrentRenderPosition { get; } = new double[] { 0 };
         public double[] CurrentRenderValue { get; } = new double[] { 1000 };
 
+        public bool IsLiveTelemetryEnabled { get; set; } = true;
+
         public CurrentTelemetryDataModel CurrentTelemetry { get; set; } = new CurrentTelemetryDataModel();
         public PlottableSignalXY[] GearGraph { get; } = new PlottableSignalXY[3];
         public DispatcherTimer GraphRenderTimer { get; } = new DispatcherTimer();
@@ -51,6 +54,7 @@ namespace F1Telemetry.WPF.ViewModels
         public CurrentLapDataModel[] LapData { get; } = new CurrentLapDataModel[3];
         public TelemetryManager Manager { get; } = new TelemetryManager();
         public SessionViewModel SessionInfo { get; set; } = new SessionViewModel();
+        public RelayCommand<bool> EnableLiveTelemetryCommand { get; }
         public RelayCommand<bool> SetTopmostCommand { get; }
         public PlottableSignalXY[] SpeedGraph { get; } = new PlottableSignalXY[3];
         public RelayCommand StartListeningCommand { get; }
@@ -93,6 +97,11 @@ namespace F1Telemetry.WPF.ViewModels
         private void SetTopmost(bool topmost)
         {
             IsTopmost = topmost;
+        }
+
+        private void EnableLiveTelemetry(bool enableLiveTelemetry)
+        {
+            IsLiveTelemetryEnabled = enableLiveTelemetry;
         }
 
         private async Task StartListeningAsync(object sender)

--- a/F1Telemetry.WPF/ViewModels/MainViewModel.cs
+++ b/F1Telemetry.WPF/ViewModels/MainViewModel.cs
@@ -132,9 +132,9 @@ namespace F1Telemetry.WPF.ViewModels
             IsTopmost = topmost;
         }
 
-        private void EnableLiveTelemetry(bool enableLiveTelemetry)
+        private void EnableLiveTelemetry(bool isLiveTelemetryEnabled)
         {
-            IsLiveTelemetryEnabled = enableLiveTelemetry;
+            IsLiveTelemetryEnabled = isLiveTelemetryEnabled;
         }
 
         private void ToggleToGraph((bool shouldPlot, int lapNumber) toggleLapInfo)

--- a/F1Telemetry.WPF/ViewModels/MainViewModel.cs
+++ b/F1Telemetry.WPF/ViewModels/MainViewModel.cs
@@ -6,6 +6,7 @@ using F1Telemetry.WPF.Command;
 using F1Telemetry.WPF.Model;
 using ScottPlot;
 using System;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading;
@@ -61,6 +62,8 @@ namespace F1Telemetry.WPF.ViewModels
         public PlottableSignalXY[] ThrottleGraph { get; } = new PlottableSignalXY[3];
         public UDPListener UDPListener { get; private set; }
 
+        public ObservableCollection<LapSummaryModel> LapSummaries { get; } = new ObservableCollection<LapSummaryModel>();
+
         private void ResetCurrentTelemetryIndexCursor()
         {
             CurrentTelemetryIndexCursor = 0;
@@ -90,6 +93,15 @@ namespace F1Telemetry.WPF.ViewModels
                     CurrentLapCursor = (CurrentLapCursor + 1) % LapData.Length;
                     LapData[CurrentLapCursor].Clear();
                     ResetCurrentTelemetryIndexCursor();
+
+                    App.Current.Dispatcher.Invoke(() =>
+                    {
+                        LapSummaries.Add(new LapSummaryModel
+                        {
+                            LapNumber = e.LastLapNumber,
+                            LapTime = e.LastLapTime
+                        });
+                    });
                 };
             }
         }

--- a/F1Telemetry.WPF/ViewModels/MainViewModel.cs
+++ b/F1Telemetry.WPF/ViewModels/MainViewModel.cs
@@ -6,6 +6,7 @@ using F1Telemetry.WPF.Command;
 using F1Telemetry.WPF.Model;
 using ScottPlot;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
@@ -25,6 +26,8 @@ namespace F1Telemetry.WPF.ViewModels
         {
             SetTopmostCommand = new RelayCommand<bool>(SetTopmost);
             EnableLiveTelemetryCommand = new RelayCommand<bool>(EnableLiveTelemetry);
+            ToggleToGraphCommand = new RelayCommand<(bool, int)>(ToggleToGraph);
+
 
             for (int i = 0; i < LapData.Length; i++)
             {
@@ -33,12 +36,29 @@ namespace F1Telemetry.WPF.ViewModels
 
             StartListeningCommand = new RelayCommand(async (s) => { await StartListeningAsync(s).ConfigureAwait(false); });
 
-            GraphRenderTimer.Interval = TimeSpan.FromMilliseconds(20);
+            GraphRenderTimer.Interval = TimeSpan.FromMilliseconds(33);
 
             Manager.NewSession += Manager_NewSession;
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
+
+       
+        // This is quite an unfortunate side effect of ScottPlot library and cannot control the chart rendering via
+        // MVVM. For now hold the WpfPlot reference to the model to handle the adding and removal of plot.
+        public WpfPlot SpeedGraphPlot { get; set; }
+        public WpfPlot BrakeGraphPlot { get; set; }
+        public WpfPlot ThrottleGraphPlot { get; set; }
+        public WpfPlot GearGraphPlot { get; set; }
+
+        /// <summary>
+        /// Holds the plotted graph reference.
+        /// </summary>
+        /// <value>
+        /// The plotted lap data.
+        /// </value>
+        private Dictionary<int, Plottable[]> PlottedLapData { get; } = new Dictionary<int, Plottable[]>();
+
 
         public PlottableSignalXY[] BrakeGraph { get; } = new PlottableSignalXY[3];
         public int CurrentLapCursor { get; set; }
@@ -57,6 +77,7 @@ namespace F1Telemetry.WPF.ViewModels
         public SessionViewModel SessionInfo { get; set; } = new SessionViewModel();
         public RelayCommand<bool> EnableLiveTelemetryCommand { get; }
         public RelayCommand<bool> SetTopmostCommand { get; }
+        public RelayCommand<(bool, int)> ToggleToGraphCommand { get; }
         public PlottableSignalXY[] SpeedGraph { get; } = new PlottableSignalXY[3];
         public RelayCommand StartListeningCommand { get; }
         public PlottableSignalXY[] ThrottleGraph { get; } = new PlottableSignalXY[3];
@@ -94,7 +115,7 @@ namespace F1Telemetry.WPF.ViewModels
                     LapData[CurrentLapCursor].Clear();
                     ResetCurrentTelemetryIndexCursor();
 
-                    App.Current.Dispatcher.Invoke(() =>
+                    System.Windows.Application.Current.Dispatcher.Invoke(() =>
                     {
                         LapSummaries.Add(new LapSummaryModel
                         {
@@ -114,6 +135,62 @@ namespace F1Telemetry.WPF.ViewModels
         private void EnableLiveTelemetry(bool enableLiveTelemetry)
         {
             IsLiveTelemetryEnabled = enableLiveTelemetry;
+        }
+
+        private void ToggleToGraph((bool shouldPlot, int lapNumber) toggleLapInfo)
+        {
+            if (toggleLapInfo.shouldPlot && !PlottedLapData.ContainsKey(toggleLapInfo.lapNumber))
+            {
+                var player = Manager.GetPlayerInfo();
+
+                var lapData = player.LapData.GetLap(toggleLapInfo.lapNumber).ToArray();
+                var carData = player.CarTelemetryData.GetForLap(lapData);
+
+                var lapNumberLabel = $"Lap {toggleLapInfo.lapNumber}";
+
+                var distance = lapData.Select(l => (double)l.LapDistance);
+
+                var speed = carData.Select(c => (double)c.Speed);
+                var throttle = carData.Select(c => (double)c.Throttle);
+                var brake = carData.Select(c => (double)c.Brake);
+                var gear = carData.Select(c => (double)c.Gear);
+
+                var graphPlots = new Plottable[4];
+
+                var speedGraphPlot = SpeedGraphPlot.plt.PlotScatter(distance.ToArray(), speed.ToArray(), lineWidth: 1.75, markerShape: MarkerShape.none);
+                speedGraphPlot.label = lapNumberLabel;
+                
+                var throttleGraphPlot = ThrottleGraphPlot.plt.PlotScatter(distance.ToArray(), throttle.ToArray(), lineWidth: 1.75, markerShape: MarkerShape.none);
+                throttleGraphPlot.label = lapNumberLabel;
+
+                var brakeGraphPlot = BrakeGraphPlot.plt.PlotScatter(distance.ToArray(), brake.ToArray(), lineWidth: 1.75, markerShape: MarkerShape.none);
+                brakeGraphPlot.label = lapNumberLabel;
+
+
+                var gearGraphPlot = GearGraphPlot.plt.PlotScatter(distance.ToArray(), gear.ToArray(), lineWidth: 1.75, markerShape: MarkerShape.none);
+                gearGraphPlot.label = lapNumberLabel;
+
+                graphPlots[0] = speedGraphPlot;
+                graphPlots[1] = throttleGraphPlot;
+                graphPlots[2] = brakeGraphPlot;
+                graphPlots[3] = gearGraphPlot;
+
+
+                PlottedLapData.Add(toggleLapInfo.lapNumber, graphPlots);
+            }
+
+            if (!toggleLapInfo.shouldPlot)
+            {
+                if (PlottedLapData.TryGetValue(toggleLapInfo.lapNumber, out Plottable[] plots))
+                {
+                    SpeedGraphPlot.plt.Remove(plots[0]);
+                    ThrottleGraphPlot.plt.Remove(plots[1]);
+                    BrakeGraphPlot.plt.Remove(plots[2]);
+                    GearGraphPlot.plt.Remove(plots[3]);
+
+                    PlottedLapData.Remove(toggleLapInfo.lapNumber);
+                }
+            }
         }
 
         private async Task StartListeningAsync(object sender)

--- a/F1Telemetry.WPF/ViewModels/MainViewModel.cs
+++ b/F1Telemetry.WPF/ViewModels/MainViewModel.cs
@@ -45,7 +45,7 @@ namespace F1Telemetry.WPF.ViewModels
         public double[] CurrentRenderPosition { get; } = new double[] { 0 };
         public double[] CurrentRenderValue { get; } = new double[] { 1000 };
 
-        public bool IsLiveTelemetryEnabled { get; set; } = true;
+        public bool IsLiveTelemetryEnabled { get; set; }
 
         public CurrentTelemetryDataModel CurrentTelemetry { get; set; } = new CurrentTelemetryDataModel();
         public PlottableSignalXY[] GearGraph { get; } = new PlottableSignalXY[3];

--- a/F1Telemetry.WPF/ViewModels/MainViewModel.cs
+++ b/F1Telemetry.WPF/ViewModels/MainViewModel.cs
@@ -183,32 +183,35 @@ namespace F1Telemetry.WPF.ViewModels
                 }
                 else
                 {
-                    CurrentRenderPosition[0] = currentLapData.LapDistance;
+                    if (IsLiveTelemetryEnabled)
+                    {
+                        CurrentRenderPosition[0] = currentLapData.LapDistance;
 
-                    var currentLapDataModel = LapData[CurrentLapCursor];
+                        var currentLapDataModel = LapData[CurrentLapCursor];
 
-                    var lapNumberLabel = $"Lap {currentLapData.CurrentLapNum}";
+                        var lapNumberLabel = $"Lap {currentLapData.CurrentLapNum}";
 
-                    currentLapDataModel.Speed[CurrentTelemetryIndexCursor] = currentTelemetry.Speed;
-                    currentLapDataModel.Distance[CurrentTelemetryIndexCursor] = currentLapData.LapDistance;
-                    currentLapDataModel.Gear[CurrentTelemetryIndexCursor] = currentTelemetry.Gear;
+                        currentLapDataModel.Speed[CurrentTelemetryIndexCursor] = currentTelemetry.Speed;
+                        currentLapDataModel.Distance[CurrentTelemetryIndexCursor] = currentLapData.LapDistance;
+                        currentLapDataModel.Gear[CurrentTelemetryIndexCursor] = currentTelemetry.Gear;
 
-                    currentLapDataModel.Throttle[CurrentTelemetryIndexCursor] = currentTelemetry.Throttle;
-                    currentLapDataModel.Brake[CurrentTelemetryIndexCursor] = currentTelemetry.Brake;
+                        currentLapDataModel.Throttle[CurrentTelemetryIndexCursor] = currentTelemetry.Throttle;
+                        currentLapDataModel.Brake[CurrentTelemetryIndexCursor] = currentTelemetry.Brake;
 
-                    SpeedGraph[CurrentLapCursor].maxRenderIndex = CurrentTelemetryIndexCursor;
-                    SpeedGraph[CurrentLapCursor].label = lapNumberLabel;
+                        SpeedGraph[CurrentLapCursor].maxRenderIndex = CurrentTelemetryIndexCursor;
+                        SpeedGraph[CurrentLapCursor].label = lapNumberLabel;
 
-                    GearGraph[CurrentLapCursor].maxRenderIndex = CurrentTelemetryIndexCursor;
-                    GearGraph[CurrentLapCursor].label = lapNumberLabel;
+                        GearGraph[CurrentLapCursor].maxRenderIndex = CurrentTelemetryIndexCursor;
+                        GearGraph[CurrentLapCursor].label = lapNumberLabel;
 
-                    BrakeGraph[CurrentLapCursor].maxRenderIndex = CurrentTelemetryIndexCursor;
-                    BrakeGraph[CurrentLapCursor].label = lapNumberLabel;
+                        BrakeGraph[CurrentLapCursor].maxRenderIndex = CurrentTelemetryIndexCursor;
+                        BrakeGraph[CurrentLapCursor].label = lapNumberLabel;
 
-                    ThrottleGraph[CurrentLapCursor].maxRenderIndex = CurrentTelemetryIndexCursor;
-                    ThrottleGraph[CurrentLapCursor].label = lapNumberLabel;
+                        ThrottleGraph[CurrentLapCursor].maxRenderIndex = CurrentTelemetryIndexCursor;
+                        ThrottleGraph[CurrentLapCursor].label = lapNumberLabel;
 
-                    CurrentTelemetryIndexCursor++;
+                        CurrentTelemetryIndexCursor++;
+                    }
                 }
 
                 UpdateCurrentTelemetry(currentTelemetry);

--- a/F1Telemetry.WPF/ViewModels/MainViewModel.cs
+++ b/F1Telemetry.WPF/ViewModels/MainViewModel.cs
@@ -12,6 +12,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Threading;
 
@@ -125,6 +126,22 @@ namespace F1Telemetry.WPF.ViewModels
                     });
                 };
             }
+
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                LapSummaries.Clear();
+            });
+
+
+            foreach (var plots in PlottedLapData)
+            {
+                SpeedGraphPlot.plt.Remove(plots.Value[0]);
+                ThrottleGraphPlot.plt.Remove(plots.Value[1]);
+                BrakeGraphPlot.plt.Remove(plots.Value[2]);
+                GearGraphPlot.plt.Remove(plots.Value[3]);
+            }
+
+            PlottedLapData.Clear();
         }
 
         private void SetTopmost(bool topmost)


### PR DESCRIPTION
This PR:
- Add ability to toggle live telemetry graph
- Turn off live telemetry graph by default
- Add time leaderboard
- Add the ability to choose which lap to plot
- Fix accidental multiple render line

![Screenshot 2020-09-16 162104](https://user-images.githubusercontent.com/9620862/93294902-f11c1900-f83f-11ea-96fb-e0fd4baa3bed.jpg)

Closes #26, #30 
