### PR TITLE
#39 Lock Graph Axis Bound

### DIFF
--- a/F1Telemetry.WPF/ViewModels/MainViewModel.cs
+++ b/F1Telemetry.WPF/ViewModels/MainViewModel.cs
@@ -437,14 +437,9 @@ namespace F1Telemetry.WPF.ViewModels
                 BrakeGraph[i] = BrakeGraphPlot.plt.PlotSignalXY(LapData[i].Distance, LapData[i].Brake, lineWidth: DefaultLineWidth);
                 ThrottleGraph[i] = ThrottleGraphPlot.plt.PlotSignalXY(LapData[i].Distance, LapData[i].Throttle, lineWidth: DefaultLineWidth);
 
-                SpeedGraphPlot.plt.Axis(0, 6000, 0, 360);
-                GearGraphPlot.plt.Axis(0, 6000, 0, 9);
-
-                ThrottleGraphPlot.plt.Axis(0, 6000, 0, 1.05);
                 ThrottleGraphPlot.plt.YLabel("Throttle");
                 ThrottleGraphPlot.plt.Legend();
 
-                BrakeGraphPlot.plt.Axis(0, 6000, 0, 1.05);
                 BrakeGraphPlot.plt.YLabel("Brake");
                 BrakeGraphPlot.plt.Legend();
             }

--- a/F1Telemetry.WPF/ViewModels/MainViewModel.cs
+++ b/F1Telemetry.WPF/ViewModels/MainViewModel.cs
@@ -117,6 +117,7 @@ namespace F1Telemetry.WPF.ViewModels
                 SessionInfo.TrackLength = (ushort)(Manager.Session != null ? Manager.Session.TrackLength : 0);
 
                 UpdateGraphXAxisToTrackLength();
+                LimitGraphAxisBound();
 
                 ResetRenderCursor();
 
@@ -147,6 +148,14 @@ namespace F1Telemetry.WPF.ViewModels
             });
 
             ClearPlottedLapData();
+        }
+
+        private void LimitGraphAxisBound()
+        {
+            SpeedGraphPlot.plt.AxisBounds(minX: 0, maxX: Manager.Session.TrackLength, minY: 0, maxY: 360);
+            ThrottleGraphPlot.plt.AxisBounds(minX: 0, maxX: Manager.Session.TrackLength, minY: 0, maxY: 1.02);
+            BrakeGraphPlot.plt.AxisBounds(minX: 0, maxX: Manager.Session.TrackLength, minY: 0, maxY: 1.02);
+            GearGraphPlot.plt.AxisBounds(minX: 0, maxX: Manager.Session.TrackLength, minY: 0, maxY: 9);
         }
 
         private void SetTopmost(bool topmost)


### PR DESCRIPTION
This PR set the graph bound when track length information in known.

Initial:

![Screenshot 2020-09-21 175530](https://user-images.githubusercontent.com/9620862/93737009-1214ad80-fc36-11ea-8887-016db23c7d6a.jpg)

Zoom on speed graph:

![Screenshot 2020-09-21 175550](https://user-images.githubusercontent.com/9620862/93737094-5902a300-fc36-11ea-8452-e486077af7b5.jpg)

Reset using middle click:

![Screenshot 2020-09-21 175600](https://user-images.githubusercontent.com/9620862/93737102-5ef88400-fc36-11ea-89d2-198304d1c8c5.jpg)


Closes #39 