### PR TITLE
#31 Fix Duplicate Data When Pitting

### DIFF
--- a/F1Telemetry.Core/Data/Driver.cs
+++ b/F1Telemetry.Core/Data/Driver.cs
@@ -81,7 +81,6 @@ namespace F1Telemetry.Core.Data
                 OnNewLap(newLapEventArgs);
 
 
-                CurrentLapInterval++;
             }
 
             CurrentLapNumber = lapData.CurrentLapNum;

--- a/F1Telemetry.Core/Data/Driver.cs
+++ b/F1Telemetry.Core/Data/Driver.cs
@@ -9,8 +9,6 @@ namespace F1Telemetry.Core.Data
     /// </summary>
     public class Driver
     {
-        private int CurrentLapInterval = 1;
-
         // TODO: Try using Dictionary to hold all of the packets of a particular lap. Use Lap number as the key? It also needs to match the
         // session ID.
         private readonly List<LapData> lapData = new List<LapData>();
@@ -19,8 +17,6 @@ namespace F1Telemetry.Core.Data
         {
             Manager = manager;
         }
-
-        public event EventHandler LapInterval;
 
         public event EventHandler<NewLapEventArgs> NewLap;
 
@@ -51,7 +47,6 @@ namespace F1Telemetry.Core.Data
             get { return lapData.AsReadOnly(); }
         }
 
-        public int LapIntervalThreshold { get; set; } = 3;
         public TelemetryManager Manager { get; }
 
         public void AddLapData(LapData lapData)
@@ -82,11 +77,6 @@ namespace F1Telemetry.Core.Data
 
                 OnNewLap(newLapEventArgs);
 
-                if (CurrentLapInterval == LapIntervalThreshold)
-                {
-                    OnLapInterval();
-                    CurrentLapInterval = 0;
-                }
 
                 CurrentLapInterval++;
             }

--- a/F1Telemetry.Core/Data/Driver.cs
+++ b/F1Telemetry.Core/Data/Driver.cs
@@ -42,6 +42,8 @@ namespace F1Telemetry.Core.Data
 
         public CarStatusData CurrentCarStatus => CarStatusData.LastOrDefault();
 
+        public LapData CurrentLapData { get; private set; }
+
         public IReadOnlyCollection<LapData> LapData
         {
             get { return lapData.AsReadOnly(); }
@@ -51,6 +53,7 @@ namespace F1Telemetry.Core.Data
 
         public void AddLapData(LapData lapData)
         {
+            CurrentLapData = lapData;
             this.lapData.Add(lapData);
 
             if (CurrentLapNumber == 0)

--- a/F1Telemetry.Core/Data/Driver.cs
+++ b/F1Telemetry.Core/Data/Driver.cs
@@ -23,11 +23,10 @@ namespace F1Telemetry.Core.Data
 
         public event EventHandler Pitting;
 
-        public DriverStatusInfo CurrentStatus { get; } = new DriverStatusInfo();
-
-        public IList<CarTelemetryData> CarTelemetryData { get; internal set; } = new List<CarTelemetryData>();
-
         public IList<CarStatusData> CarStatusData { get; internal set; } = new List<CarStatusData>();
+        public IList<CarTelemetryData> CarTelemetryData { get; internal set; } = new List<CarTelemetryData>();
+        public CarStatusData CurrentCarStatus => CarStatusData.LastOrDefault();
+        public LapData CurrentLapData { get; private set; }
 
         /// <summary>
         /// Gets or sets the number of laps the driver had done.
@@ -37,6 +36,8 @@ namespace F1Telemetry.Core.Data
         /// </value>
         public int CurrentLapNumber { get; private set; } = 0;
 
+        public DriverStatusInfo CurrentStatus { get; } = new DriverStatusInfo();
+
         /// <summary>
         /// Gets the current telemetry.
         /// </summary>
@@ -45,16 +46,17 @@ namespace F1Telemetry.Core.Data
         /// </value>
         public CarTelemetryData CurrentTelemetry => CarTelemetryData.LastOrDefault();
 
-        public CarStatusData CurrentCarStatus => CarStatusData.LastOrDefault();
-
-        public LapData CurrentLapData { get; private set; }
-
         public IReadOnlyCollection<LapData> LapData
         {
             get { return lapData.ToList().AsReadOnly(); }
         }
 
         public TelemetryManager Manager { get; }
+
+        public void AddCarStatusData(CarStatusData carStatusData)
+        {
+            this.CarStatusData.Add(carStatusData);
+        }
 
         /// <summary>
         /// Adds the valid lap data.
@@ -104,11 +106,6 @@ namespace F1Telemetry.Core.Data
             CurrentLapNumber = lapData.CurrentLapNum;
         }
 
-        private bool IsLapDataValid(LapData lapData)
-        {
-            return lapData.PitStatus == PitStatus.None && (lapData.DriverStatus.Equals(DriverStatus.FlyingLap) || lapData.DriverStatus.Equals(DriverStatus.OnTrack));
-        }
-
         /// <summary>
         /// Removes the lap data of the specified lap number.
         /// </summary>
@@ -129,11 +126,6 @@ namespace F1Telemetry.Core.Data
             }
         }
 
-        public void AddCarStatusData(CarStatusData carStatusData)
-        {
-            this.CarStatusData.Add(carStatusData);
-        }
-
         protected virtual void OnNewLap(NewLapEventArgs e)
         {
             NewLap?.Invoke(this, e);
@@ -142,6 +134,11 @@ namespace F1Telemetry.Core.Data
         protected virtual void OnPitting()
         {
             Pitting?.Invoke(this, EventArgs.Empty);
+        }
+
+        private bool IsLapDataValid(LapData lapData)
+        {
+            return lapData.PitStatus == PitStatus.None && (lapData.DriverStatus.Equals(DriverStatus.FlyingLap) || lapData.DriverStatus.Equals(DriverStatus.OnTrack));
         }
 
         private void UpdateDriverStatusInfo(LapData lapData)

--- a/F1Telemetry.Core/Data/Driver.cs
+++ b/F1Telemetry.Core/Data/Driver.cs
@@ -46,7 +46,7 @@ namespace F1Telemetry.Core.Data
 
         public IReadOnlyCollection<LapData> LapData
         {
-            get { return lapData.AsReadOnly(); }
+            get { return lapData.ToList().AsReadOnly(); }
         }
 
         public TelemetryManager Manager { get; }

--- a/F1Telemetry.Core/Data/Driver.cs
+++ b/F1Telemetry.Core/Data/Driver.cs
@@ -20,6 +20,8 @@ namespace F1Telemetry.Core.Data
 
         public event EventHandler<NewLapEventArgs> NewLap;
 
+        public DriverStatusInfo CurrentStatus { get; } = new DriverStatusInfo();
+
         public IList<CarTelemetryData> CarTelemetryData { get; internal set; } = new List<CarTelemetryData>();
 
         public IList<CarStatusData> CarStatusData { get; internal set; } = new List<CarStatusData>();
@@ -99,6 +101,10 @@ namespace F1Telemetry.Core.Data
         protected virtual void OnNewLap(NewLapEventArgs e)
         {
             NewLap?.Invoke(this, e);
+        private void UpdateDriverStatusInfo(LapData lapData)
+        {
+            CurrentStatus.PitStatus = lapData.PitStatus;
+            CurrentStatus.Status = lapData.DriverStatus;
         }
     }
 

--- a/F1Telemetry.Core/Data/Driver.cs
+++ b/F1Telemetry.Core/Data/Driver.cs
@@ -82,10 +82,24 @@ namespace F1Telemetry.Core.Data
 
                 OnNewLap(newLapEventArgs);
 
+        /// <summary>
+        /// Removes the lap data of the specified lap number.
+        /// </summary>
+        /// <param name="lapNumber">The lap number.</param>
+        public void RemoveLap(int lapNumber)
+        {
+            var lapDataToRemove = lapData.GetLap(lapNumber).ToList();
+            var carDataToRemove = CarTelemetryData.GetForLap(lapDataToRemove);
 
+            foreach (var lapData in lapDataToRemove)
+            {
+                this.lapData.Remove(lapData);
             }
 
-            CurrentLapNumber = lapData.CurrentLapNum;
+            foreach (var item in carDataToRemove)
+            {
+                CarTelemetryData.Remove(item);
+            }
         }
 
         public void AddCarStatusData(CarStatusData carStatusData)

--- a/F1Telemetry.Core/Data/DriverStatusInfo.cs
+++ b/F1Telemetry.Core/Data/DriverStatusInfo.cs
@@ -9,7 +9,7 @@ namespace F1Telemetry.Core.Data
     /// </summary>
     public class DriverStatusInfo
     {
-        public PitStatus PitStatus { get; set; }
+        public PitStatus PitStatus { get; set; } = PitStatus.Invalid;
         public DriverStatus Status { get; set; }
     }
 }

--- a/F1Telemetry.Core/Data/DriverStatusInfo.cs
+++ b/F1Telemetry.Core/Data/DriverStatusInfo.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace F1Telemetry.Core.Data
+{
+    /// <summary>
+    /// Contains the Driver Status.
+    /// </summary>
+    public class DriverStatusInfo
+    {
+        public PitStatus PitStatus { get; set; }
+        public DriverStatus Status { get; set; }
+    }
+}

--- a/F1Telemetry.Core/Data/LapData.cs
+++ b/F1Telemetry.Core/Data/LapData.cs
@@ -186,6 +186,8 @@ namespace F1Telemetry.Core.Data
         Pitting,
 
         [Display(Name = "In Pit Area")]
-        InPitArea
+        InPitArea,
+
+        Invalid
     }
 }

--- a/F1Telemetry.Core/Util/Extensions/LapDataExtensions.cs
+++ b/F1Telemetry.Core/Util/Extensions/LapDataExtensions.cs
@@ -8,7 +8,7 @@ namespace F1Telemetry.Core.Util.Extensions
     {
         public static IEnumerable<LapData> GetLap(this IReadOnlyCollection<LapData> lapData, int lapNumber)
         {
-            return lapData.Where(l => lapNumber.Equals(l.CurrentLapNum) && !l.DriverStatus.Equals(DriverStatus.InGarage));
+            return lapData.Where(l => lapNumber.Equals(l.CurrentLapNum) && !l.DriverStatus.Equals(DriverStatus.InGarage) && l.PitStatus.Equals(PitStatus.None));
         }
     }
 }

--- a/F1Telemetry.Core/Util/Extensions/LapDataExtensions.cs
+++ b/F1Telemetry.Core/Util/Extensions/LapDataExtensions.cs
@@ -8,7 +8,7 @@ namespace F1Telemetry.Core.Util.Extensions
     {
         public static IEnumerable<LapData> GetLap(this IReadOnlyCollection<LapData> lapData, int lapNumber)
         {
-            return lapData.Where(l => lapNumber.Equals(l.CurrentLapNum) && !l.DriverStatus.Equals(DriverStatus.InGarage) && l.PitStatus.Equals(PitStatus.None));
+            return lapData.Where(l => lapNumber.Equals(l.CurrentLapNum) && !l.DriverStatus.Equals(DriverStatus.InGarage) && l.PitStatus.Equals(PitStatus.None)).ToList();
         }
     }
 }

--- a/F1Telemetry.Test/Core/DriverTests.cs
+++ b/F1Telemetry.Test/Core/DriverTests.cs
@@ -82,7 +82,11 @@ namespace F1Telemetry.Test.Core
                     CurrentLapNum = 2
                 });
 
-                monitoredDriver.Should().Raise(nameof(Driver.NewLap), because: "It is not considered as a new lap on first assignment.");
+                monitoredDriver
+                    .Should()
+                    .Raise(nameof(Driver.NewLap), because: "It is a new lap.")
+                    .WithSender(driver)
+                    .WithArgs<NewLapEventArgs>(e => e.LastLapNumber.Equals(1));
             }
         }
     }

--- a/F1Telemetry.Test/Core/DriverTests.cs
+++ b/F1Telemetry.Test/Core/DriverTests.cs
@@ -45,5 +45,45 @@ namespace F1Telemetry.Test.Core
                 monitoredDriver.Should().NotRaise(nameof(Driver.Pitting));
             }
         }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void NewLap_Should_Not_Raise_When_First_Initialised(byte lapNumber)
+        {
+            var driver = new Driver(new F1Telemetry.Core.TelemetryManager());
+
+            using (var monitoredDriver = driver.Monitor())
+            {
+                driver.AddLapData(new LapData
+                {
+                    CurrentLapNum = lapNumber
+                });
+
+                monitoredDriver.Should().NotRaise(nameof(Driver.NewLap), because: "It is not considered as a new lap on first assignment.");
+            }
+        }
+
+        [Fact]
+        public void NewLap_Should_Raise_When_Lap_Number_Is_Increases()
+        {
+            var driver = new Driver(new F1Telemetry.Core.TelemetryManager());
+
+            using (var monitoredDriver = driver.Monitor())
+            {
+                driver.AddLapData(new LapData
+                {
+                    CurrentLapNum = 1
+                });
+
+                driver.AddLapData(new LapData
+                {
+                    CurrentLapNum = 2
+                });
+
+                monitoredDriver.Should().Raise(nameof(Driver.NewLap), because: "It is not considered as a new lap on first assignment.");
+            }
+        }
     }
 }

--- a/F1Telemetry.Test/Core/DriverTests.cs
+++ b/F1Telemetry.Test/Core/DriverTests.cs
@@ -1,0 +1,49 @@
+﻿using F1Telemetry.Core.Data;
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace F1Telemetry.Test.Core
+{
+    public class DriverTests
+    {
+        [Fact]
+        public void Pitting_Should_Raise_When_Status_Changed_To_Pitting_From_Other_Status()
+        {
+            var driver = new Driver(new F1Telemetry.Core.TelemetryManager());
+
+            using(var monitoredDriver = driver.Monitor())
+            {
+                driver.AddLapData(new LapData
+                {
+                    PitStatus = PitStatus.None
+                });
+
+                driver.AddLapData(new LapData
+                {
+                    PitStatus = PitStatus.Pitting
+                });
+
+                monitoredDriver.Should().Raise(nameof(Driver.Pitting));
+            }
+        }
+
+        [Fact]
+        public void Pitting_Should_Not_Raise_When_Initially_Set_And_Driver_Starts_From_Garage()
+        {
+            var driver = new Driver(new F1Telemetry.Core.TelemetryManager());
+
+            using (var monitoredDriver = driver.Monitor())
+            {
+                driver.AddLapData(new LapData
+                {
+                    PitStatus = PitStatus.Pitting
+                });
+
+                monitoredDriver.Should().NotRaise(nameof(Driver.Pitting));
+            }
+        }
+    }
+}

--- a/F1Telemetry.WPF/ViewModels/MainViewModel.cs
+++ b/F1Telemetry.WPF/ViewModels/MainViewModel.cs
@@ -178,7 +178,7 @@ namespace F1Telemetry.WPF.ViewModels
             {
                 var player = Manager.GetPlayerInfo();
 
-                var lapData = player.LapData.GetLap(toggleLapInfo.lapNumber).ToArray();
+                var lapData = player.LapData.GetLap(toggleLapInfo.lapNumber);
                 var carData = player.CarTelemetryData.GetForLap(lapData);
 
                 var lapNumberLabel = $"Lap {toggleLapInfo.lapNumber}";

--- a/F1Telemetry.WPF/ViewModels/MainViewModel.cs
+++ b/F1Telemetry.WPF/ViewModels/MainViewModel.cs
@@ -335,7 +335,7 @@ namespace F1Telemetry.WPF.ViewModels
             Manager.Feed(eventArgs.Bytes);
 
             var currentTelemetry = Manager.GetPlayerInfo()?.CurrentTelemetry;
-            var currentLapData = Manager.GetPlayerInfo()?.LapData.LastOrDefault();
+            var currentLapData = Manager.GetPlayerInfo()?.CurrentLapData;
             var currentCarStatus = Manager.GetPlayerInfo()?.CurrentCarStatus;
 
             if (currentTelemetry != null)

--- a/F1Telemetry.WPF/ViewModels/MainViewModel.cs
+++ b/F1Telemetry.WPF/ViewModels/MainViewModel.cs
@@ -140,6 +140,10 @@ namespace F1Telemetry.WPF.ViewModels
                         });
                     });
                 };
+
+                manager.GetPlayerInfo().Pitting += (s, e) => {
+                    manager.GetPlayerInfo().RemoveLap(CurrentTelemetry.LapNumber);
+                };
             }
 
             Application.Current.Dispatcher.Invoke(() =>


### PR DESCRIPTION
This PR:
- Fixes #31 
- Removed Unused Event
- Time Trial on Duplicate Data is not Fix; This might relate more to Restart Issue than to this one
- Create CurrentLapData Prop
- Only record lap data when Driver is On Flying Lap or On Track and NOT Pitting
- Create a snapshot when asked for Lap Data
- Added new test
