### PR TITLE
AB#47 Add Sector Times

### DIFF
--- a/F1Telemetry.Core/Data/Driver.cs
+++ b/F1Telemetry.Core/Data/Driver.cs
@@ -119,7 +119,7 @@ namespace F1Telemetry.Core.Data
                     }
                 }
 
-                var lapSummary = new LapSummary(previousLapNum, lapData.LastLapTime, lapData.BestLapTime, lapDatas: lastLapData, carTelemetryDatas: lastCarTelemetryData, carStatusDatas: lastCarStatusData);
+                var lapSummary = new LapSummary(lapData, lapDatas: lastLapData, carTelemetryDatas: lastCarTelemetryData, carStatusDatas: lastCarStatusData);
 
                 LapSummaries.Add(CurrentLapNumber, lapSummary);
 

--- a/F1Telemetry.Core/Data/LapSummary.cs
+++ b/F1Telemetry.Core/Data/LapSummary.cs
@@ -25,14 +25,22 @@ namespace F1Telemetry.Core.Data
         public float ERSDeployedPercentage => ERSDeployed / CarInfo.F1.MaxDeployableERS;
         public float FuelUsed => CalculateFuelUsage();
 
-        public LapSummary(int lapNumber, float lapTime, float bestLapTime, List<LapData> lapDatas, List<CarStatusData> carStatusDatas, List<CarTelemetryData> carTelemetryDatas)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LapSummary"/> class.
+        /// </summary>
+        /// <param name="latestLapData">The latest lap data given from the game. This is usually the next packet after a new lap.</param>
+        /// <param name="lapDatas">The lap datas.</param>
+        /// <param name="carStatusDatas">The car status datas.</param>
+        /// <param name="carTelemetryDatas">The car telemetry datas.</param>
+        public LapSummary(LapData latestLapData, List<LapData> lapDatas, List<CarStatusData> carStatusDatas, List<CarTelemetryData> carTelemetryDatas)
         {
             LapData = lapDatas.AsReadOnly();
             CarStatusData = carStatusDatas.AsReadOnly();
             CarTelemetryData = carTelemetryDatas.AsReadOnly();
-            LapNumber = lapNumber;
-            LapTime = lapTime;
-            BestLapTime = bestLapTime;
+
+            LapNumber = latestLapData.CurrentLapNum - 1;
+            LapTime = latestLapData.LastLapTime;
+            BestLapTime = latestLapData.BestLapTime;
 
             var carStatus = carStatusDatas.LastOrDefault();
 

--- a/F1Telemetry.Core/Data/LapSummary.cs
+++ b/F1Telemetry.Core/Data/LapSummary.cs
@@ -11,6 +11,7 @@ namespace F1Telemetry.Core.Data
     {
         public int LapNumber { get; }
         public float LapTime { get; }
+        public SectorTime SectorTime { get; }
         public float BestLapTime { get; }
         public IReadOnlyList<LapData> LapData { get; }
         public IReadOnlyList<CarStatusData> CarStatusData { get; }
@@ -41,6 +42,17 @@ namespace F1Telemetry.Core.Data
             LapNumber = latestLapData.CurrentLapNum - 1;
             LapTime = latestLapData.LastLapTime;
             BestLapTime = latestLapData.BestLapTime;
+
+            var lapData = lapDatas.LastOrDefault();
+
+            if (lapData != null)
+            {
+                var sector1 = lapData.Sector1TimeInMS / 1000.0f;
+                var sector2 = lapData.Sector2TimeInMS / 1000.0f;
+                var sector3 = LapTime - sector1 - sector2;
+
+                SectorTime = new SectorTime(sector1, sector2, sector3);
+            }
 
             var carStatus = carStatusDatas.LastOrDefault();
 

--- a/F1Telemetry.Core/Data/LapSummary.cs
+++ b/F1Telemetry.Core/Data/LapSummary.cs
@@ -35,9 +35,11 @@ namespace F1Telemetry.Core.Data
         /// <param name="carTelemetryDatas">The car telemetry datas.</param>
         public LapSummary(LapData latestLapData, List<LapData> lapDatas, List<CarStatusData> carStatusDatas, List<CarTelemetryData> carTelemetryDatas)
         {
-            LapData = lapDatas.AsReadOnly();
-            CarStatusData = carStatusDatas.AsReadOnly();
-            CarTelemetryData = carTelemetryDatas.AsReadOnly();
+            _ = latestLapData ?? throw new ArgumentNullException(nameof(latestLapData));
+
+            LapData = lapDatas ?? throw new ArgumentNullException(nameof(lapDatas));
+            CarStatusData = carStatusDatas ?? throw new ArgumentNullException(nameof(carStatusDatas));
+            CarTelemetryData = carTelemetryDatas ?? throw new ArgumentNullException(nameof(carTelemetryDatas));
 
             LapNumber = latestLapData.CurrentLapNum - 1;
             LapTime = latestLapData.LastLapTime;

--- a/F1Telemetry.Core/Data/SectorTime.cs
+++ b/F1Telemetry.Core/Data/SectorTime.cs
@@ -1,0 +1,16 @@
+﻿namespace F1Telemetry.Core.Data
+{
+    public class SectorTime
+    {
+        public float Sector1 { get; }
+        public float Sector2 { get; }
+        public float Sector3 { get; }
+
+        public SectorTime(float sector1, float sector2, float sector3)
+        {
+            Sector1 = sector1;
+            Sector2 = sector2;
+            Sector3 = sector3;
+        }
+    }
+}

--- a/F1Telemetry.Test/ConverterTests/ToLapTimeStringTest.cs
+++ b/F1Telemetry.Test/ConverterTests/ToLapTimeStringTest.cs
@@ -12,6 +12,7 @@ namespace F1Telemetry.Test.ConverterTests
     public class ToLapTimeStringTest
     {
         [Theory]
+        [InlineData(10, "10.000")]
         [InlineData(60, "01:00.000")]
         [InlineData(70, "01:10.000")]
         [InlineData(155.364, "02:35.364")]

--- a/F1Telemetry.Test/Core/LapSummaryTest.cs
+++ b/F1Telemetry.Test/Core/LapSummaryTest.cs
@@ -26,7 +26,7 @@ namespace F1Telemetry.Test.Core
                 }
             };
 
-            var lapSummary = new LapSummary(0, 0, 0, new List<LapData>(), carStatusData, new List<CarTelemetryData>());
+            var lapSummary = new LapSummary(new LapData(0, 0), new List<LapData>(), carStatusData, new List<CarTelemetryData>());
 
             var actual = lapSummary.ERSDeployedPercentage;
 
@@ -50,7 +50,7 @@ namespace F1Telemetry.Test.Core
                 }
             };
 
-            var lapSummary = new LapSummary(0, 0, 0, new List<LapData>(), carStatusData, new List<CarTelemetryData>());
+            var lapSummary = new LapSummary(new LapData(0, 0), new List<LapData>(), carStatusData, new List<CarTelemetryData>());
 
             var actual = lapSummary.TotalERSHarvestedPercentage;
 
@@ -75,7 +75,7 @@ namespace F1Telemetry.Test.Core
                 }
             };
 
-            var lapSummary = new LapSummary(0, 0, 0, new List<LapData>(), carStatusData, new List<CarTelemetryData>());
+            var lapSummary = new LapSummary(new LapData(0, 0), new List<LapData>(), carStatusData, new List<CarTelemetryData>());
 
             var actual = lapSummary.TotalERSHarvested;
 
@@ -106,7 +106,7 @@ namespace F1Telemetry.Test.Core
                 }
             };
 
-            var lapSummary = new LapSummary(0, 0, 0, new List<LapData>(), carStatusData, new List<CarTelemetryData>());
+            var lapSummary = new LapSummary(new LapData(0, 0), new List<LapData>(), carStatusData, new List<CarTelemetryData>());
 
             lapSummary.FuelUsed.Should().BeApproximately(6.0f, 0.01f);
         }
@@ -126,7 +126,7 @@ namespace F1Telemetry.Test.Core
                 }
             };
 
-            var lapSummary = new LapSummary(0, 0, 0, new List<LapData>(), carStatusData, new List<CarTelemetryData>());
+            var lapSummary = new LapSummary(new LapData(0, 0), new List<LapData>(), carStatusData, new List<CarTelemetryData>());
 
             lapSummary.FuelUsed.Should().BeGreaterOrEqualTo(0.0f, because: "There is no refueling and a lap should always consume fuel. You can't make fuel from thin air.");
         }
@@ -134,7 +134,7 @@ namespace F1Telemetry.Test.Core
         [Fact]
         public void FuelUsed_Should_Return_Zero_When_There_Is_No_Data()
         {
-            var lapSummary = new LapSummary(0, 0, 0, new List<LapData>(), new List<CarStatusData>(), new List<CarTelemetryData>());
+            var lapSummary = new LapSummary(new LapData(0, 0), new List<LapData>(), new List<CarStatusData>(), new List<CarTelemetryData>());
 
             lapSummary.FuelUsed.Should().Be(0.0f);
         }

--- a/F1Telemetry.Test/Core/LapSummaryTest.cs
+++ b/F1Telemetry.Test/Core/LapSummaryTest.cs
@@ -9,6 +9,38 @@ namespace F1Telemetry.Test.Core
 {
     public class LapSummaryTest
     {
+        [Fact]
+        public void Contructor_Should_Throw_NullReference_If_No_Latest_LapData_Given()
+        {
+            Action action = () => new LapSummary(null, null, null, null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Contructor_Should_Throw_NullReference_If_No_LapDatas_Given()
+        {
+            Action action = () => new LapSummary(new LapData(0, 0), null, null, null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Contructor_Should_Throw_NullReference_If_No_CarStatusDatas_Given()
+        {
+            Action action = () => new LapSummary(new LapData(0, 0), new List<LapData>(), null, null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Contructor_Should_Throw_NullReference_If_No_CarTelemetryDatas_Given()
+        {
+            Action action = () => new LapSummary(new LapData(0, 0), new List<LapData>(), new List<CarStatusData>(), null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
         [Theory]
         [InlineData(100.12f)]
         [InlineData(2000.0f)]
@@ -82,7 +114,6 @@ namespace F1Telemetry.Test.Core
             actual.Should().BeApproximately(expected, 0.05f);
         }
 
-
         [Fact]
         public void FuelUsed_Should_Return_The_Difference_Between_Fuel_At_The_Start_Of_The_Lap_and_End_Of_Lap()
         {
@@ -137,6 +168,16 @@ namespace F1Telemetry.Test.Core
             var lapSummary = new LapSummary(new LapData(0, 0), new List<LapData>(), new List<CarStatusData>(), new List<CarTelemetryData>());
 
             lapSummary.FuelUsed.Should().Be(0.0f);
+        }
+
+        [Fact]
+        public void LapSummary_Should_Return_SectorTime_in_Seconds()
+        {
+            var lapSummary = new LapSummary(new LapData(0, 0) { LastLapTime = 3 }, new List<LapData> { new LapData(0, 0) { Sector1TimeInMS = 1000, Sector2TimeInMS = 1000 } }, new List<CarStatusData>(), new List<CarTelemetryData>());
+
+            var expected = new SectorTime(1, 1, 1);
+
+            lapSummary.SectorTime.Should().BeEquivalentTo(expected);
         }
     }
 }

--- a/F1Telemetry.WPF/Converter/ToLapTimeString.cs
+++ b/F1Telemetry.WPF/Converter/ToLapTimeString.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Text;
 using System.Windows.Data;
 
 namespace F1Telemetry.WPF.Converter
@@ -9,8 +10,16 @@ namespace F1Telemetry.WPF.Converter
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var time = TimeSpan.FromSeconds(double.Parse(value.ToString()));
+            var lapTimeStringBuilder = new StringBuilder();
 
-            return $"{time.Minutes:00}:{time.Seconds:00}.{time.Milliseconds:000}";
+            if (time.Minutes > 0)
+            {
+                lapTimeStringBuilder.Append($"{time.Minutes:00}:");
+            }
+
+            lapTimeStringBuilder.Append($"{time.Seconds:00}.{Math.Abs(time.Milliseconds):000}");
+
+            return lapTimeStringBuilder.ToString();
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/F1Telemetry.WPF/MainWindow.xaml
+++ b/F1Telemetry.WPF/MainWindow.xaml
@@ -110,6 +110,21 @@
                                 IsReadOnly="True"
                                 ElementStyle="{StaticResource CenterDataGridCell}" />
                             <DataGridTextColumn
+                                Header="Sector 1"
+                                Binding="{Binding SectorTime.Sector1, Converter={StaticResource ToLapTimeString}}"
+                                IsReadOnly="True"
+                                ElementStyle="{StaticResource CenterDataGridCell}" />
+                            <DataGridTextColumn
+                                Header="Sector 2"
+                                Binding="{Binding SectorTime.Sector2, Converter={StaticResource ToLapTimeString}}"
+                                IsReadOnly="True"
+                                ElementStyle="{StaticResource CenterDataGridCell}" />
+                            <DataGridTextColumn
+                                Header="Sector 3"
+                                Binding="{Binding SectorTime.Sector3, Converter={StaticResource ToLapTimeString}}"
+                                IsReadOnly="True"
+                                ElementStyle="{StaticResource CenterDataGridCell}" />
+                            <DataGridTextColumn
                                 Header="Tyre"
                                 Binding="{Binding TyreCompoundUsed}"
                                 IsReadOnly="True"

--- a/F1Telemetry.WPF/Model/LapSummaryModel.cs
+++ b/F1Telemetry.WPF/Model/LapSummaryModel.cs
@@ -8,6 +8,7 @@ namespace F1Telemetry.WPF.Model
         public bool IsChecked { get; set; }
         public int LapNumber { get; set; }
         public float LapTime { get; set; }
+        public SectorTime SectorTime { get; set; }
         public float DeltaToBestTime { get; set; }
         public TyreCompound TyreCompoundUsed { get; set; }
         public float ERSDeployed { get; set; }

--- a/F1Telemetry.WPF/ViewModels/MainViewModel.cs
+++ b/F1Telemetry.WPF/ViewModels/MainViewModel.cs
@@ -150,6 +150,7 @@ namespace F1Telemetry.WPF.ViewModels
                         {
                             LapNumber = lapSummary.LapNumber,
                             LapTime = lapSummary.LapTime,
+                            SectorTime = lapSummary.SectorTime,
                             DeltaToBestTime = deltaToFastestTime,
                             TyreCompoundUsed = lapSummary.TyreCompoundUsed,
                             ERSDeployed = lapSummary.ERSDeployed,

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 [![Build Status](https://dev.azure.com/wakatobi/F1%20Telemetry/_apis/build/status/ferdinh.F1-Telemetry?branchName=master)](https://dev.azure.com/wakatobi/F1%20Telemetry/_build/latest?definitionId=2&branchName=master)
 [![Board Status](https://dev.azure.com/wakatobi/4388704d-474f-4e54-b9b7-fd49a91ef36d/bc4d32e1-60e4-4705-98d0-15a4d558ac98/_apis/work/boardbadge/fde860e2-034f-48c4-87db-2848386b6ffb?columnOptions=1)](https://dev.azure.com/wakatobi/4388704d-474f-4e54-b9b7-fd49a91ef36d/_boards/board/t/bc4d32e1-60e4-4705-98d0-15a4d558ac98/Microsoft.RequirementCategory/)
 
-![Telemetry](https://raw.githubusercontent.com/ferdinh/F1-Telemetry/master/docs/pics/mainscreen.jpg)
+![Telemetry](https://raw.githubusercontent.com/ferdinh/F1-Telemetry/main/docs/pics/mainscreen.jpg)


### PR DESCRIPTION
This PR adds: 
- Sector Time in Lap Summary
- Null Check in Summary
- Lap Time string no longer shows Minutes if less than 60 seconds

![image](https://user-images.githubusercontent.com/9620862/95828633-b69b9280-0d91-11eb-84c8-e12f9717b235.png)

Fixes [AB#47](https://dev.azure.com/wakatobi/4388704d-474f-4e54-b9b7-fd49a91ef36d/_workitems/edit/47)